### PR TITLE
Update DefaultCutPlaneProcessing.java

### DIFF
--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/output/DefaultCutPlaneProcessing.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/output/DefaultCutPlaneProcessing.java
@@ -96,5 +96,8 @@ public class DefaultCutPlaneProcessing implements NoiseMapByReceiverMaker.ICompu
         } catch (Exception e) {
             throw new SQLException(e);
         }
+        // Shutdown the thread pool
+        // previously submitted tasks are executed, but no new tasks will be accepted.
+        postProcessingThreadPool.shutdown();
     }
 }


### PR DESCRIPTION
Shutdown thread pool. NoiseModelling was hanging because one thread could avoid the jvm to stop.