### PR TITLE
log4j.properties

### DIFF
--- a/wps_scripts/src/main/resources/org/noise_planet/noisemodelling/runner/log4j.properties
+++ b/wps_scripts/src/main/resources/org/noise_planet/noisemodelling/runner/log4j.properties
@@ -2,9 +2,9 @@
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%t] %-5p - %m%n
+log4j.appender.stdout.layout.ConversionPattern=[%t] %-5p %d{yyyy-MM-dd HH:mm:ss} - %m%n
 
-log4j.rootCategory=INFO
+log4j.rootCategory=INFO, stdout
 
 log4j.category.org.noise_planet=INFO
 log4j.category.org.h2=INFO


### PR DESCRIPTION
To output the log in the console, stdout is needed for the log4j.rootCategory.
I also think it is better to write the log in the file, although I don't know why it was removed in the previous change and I don't include that in this commit.