### PR TITLE
fix: Deploy WPS is not run on push to main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,11 +49,11 @@ jobs:
       - name: Clean gradle cache
         run: rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
       - name: Restore gradle.properties
-        if: ${{ (env.MAVEN_USERNAME != null) && (github.ref == 'refs/heads/main') }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        if: ${{ (env.MAVEN_USERNAME != null) && (github.ref == 'refs/heads/main') }}
         shell: bash
         run: |
           mkdir -p ~/.gradle/
@@ -62,6 +62,10 @@ jobs:
           echo "ossrhPassword=${MAVEN_PASSWORD}" >> ~/.gradle/gradle.properties
           echo "signing.gnupg.passphrase=${MAVEN_GPG_PASSPHRASE}" >> ~/.gradle/gradle.properties
       - name: Deploy WPS
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         if: ${{ (env.MAVEN_USERNAME != null) && (github.ref == 'refs/heads/main') }}
         run: ./gradlew uploadArchives
         working-directory: ./wps_scripts


### PR DESCRIPTION
 The `Deploy WPS` step now explicitly defines the required environment variables (`MAVEN_USERNAME`, `MAVEN_PASSWORD`, `MAVEN_GPG_PASSPHRASE`) to ensure proper configuration during deployment.