### PR TITLE
feat: handle motorcycles in matsim

### DIFF
--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/road/cnossos/RoadCnossosParameters.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/road/cnossos/RoadCnossosParameters.java
@@ -65,14 +65,14 @@ public class RoadCnossosParameters {
      *
      * @param lv_speed    Average light vehicle speed
      * @param mv_speed    Average medium vehicle speed
-     * @param hgv_speed   Average heavy goods vehicle speed
+     * @param hgv_speed   Average heavy vehicle speed
      * @param wav_speed   Average light 2 wheels vehicle speed
      * @param wbv_speed   Average heavy 2 wheels vehicle speed
      * @param lvPerHour   Average light vehicle per hour
-     * @param mvPerHour   Average heavy vehicle per hour
-     * @param hgvPerHour  Average heavy vehicle per hour
-     * @param wavPerHour  Average heavy vehicle per hour
-     * @param wbvPerHour  Average heavy vehicle per hour
+     * @param mvPerHour   Average medium vehicles per hour
+     * @param hgvPerHour  Average heavy vehicles per hour
+     * @param wavPerHour  Average light 2 wheels vehicles per hour
+     * @param wbvPerHour  Average heavy 2 wheels vehicles per hour
      * @param frequency   Studied Frequency (must be octave band)
      * @param Temperature Temperature (Celsius)
      * @param roadSurface roadSurface empty default, NL01 FR01 .. (look at src/main/resources/org/noise_planet/noisemodelling/emission/RoadCnossos_2020.json)


### PR DESCRIPTION
This pull request updates the MATSim traffic event processing pipeline to support two-wheeled vehicles (WAV and WBV categories) in addition to cars, buses, and trucks. The changes include reading vehicle definitions from the MATSim output, categorizing vehicles more robustly, updating traffic statistics and SQL schema to include the new vehicle types

**MATSim vehicle integration and categorization:**
* Added reading of `output_allVehicles.xml.gz` and parsing of vehicle definitions using `MatsimVehicleReader`, allowing access to vehicle types and attributes in the event handler. 
* Improved vehicle type categorization with a new `Trip.getTypeFromVehicle` method, using the `CnossosCategory` attribute and vehicle type IDs to distinguish between LV, MV, HV, WAV, and WBV.

**Traffic statistics and SQL schema updates:**
* Extended the traffic SQL table schema and prepared statements to store counts and speeds for WAV and WBV vehicles, in addition to LV, MV, and HV.

**Noise calculation improvements:**
* Updated noise source level calculation methods (`calculateSourceLevels`, `calculateSourceLeq`, `calculateSourceLAeq`) to include WAV and WBV counts and speeds.

**Documentation and parameter naming:**
* Clarified and corrected parameter names and documentation in `RoadCnossosParameters.java` to reflect the distinction between vehicle types and their hourly counts.