### PR TITLE
improve height tag processing from buildings

### DIFF
--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Import_and_Export/Import_OSM.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Import_and_Export/Import_OSM.groovy
@@ -1296,8 +1296,12 @@ public class Building {
                 h = h - 4 + Double.parseDouble(tag.getValue().replaceAll("[^0-9]+", "")) * 3.0;
             }
             if ("height".equalsIgnoreCase(tag.getKey())) {
-                h = Double.parseDouble(tag.getValue().replaceAll("[^0-9]+", ""));
-                trueHeightFound = true;
+                String cleanHeight = tag.getValue().replaceAll("[^0-9.]+", "")
+                try {
+                    h = Double.parseDouble(cleanHeight);
+                    trueHeightFound = true;
+                }
+                catch (NumberFormatException e) {}
             }
         }
         this.height = h;


### PR DESCRIPTION
Updated the height parsing logic in the `Building` class within `Import_OSM.groovy` to allow decimal points in the `height` tag and added error handling for invalid number formats.