### PR TITLE
Fix issue when a sound source was placed inside a building, a recent …

### DIFF
--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/GridMapMaker.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/GridMapMaker.java
@@ -10,16 +10,12 @@
 
 package org.noise_planet.noisemodelling.jdbc;
 
-import org.h2gis.api.EmptyProgressVisitor;
-import org.h2gis.api.ProgressVisitor;
 import org.h2gis.utilities.TableLocation;
 import org.h2gis.utilities.dbtypes.DBTypes;
 import org.h2gis.utilities.dbtypes.DBUtils;
 import org.locationtech.jts.geom.*;
 import org.noise_planet.noisemodelling.jdbc.input.DefaultTableLoader;
 import org.noise_planet.noisemodelling.jdbc.utils.CellIndex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.*;
 
@@ -39,9 +35,14 @@ public abstract class GridMapMaker {
     // Digital elevation model table. (Contains points or triangles)
     protected String demTable = "";
     protected String sound_lvl_field = "DB_M";
-    // True if Z of sound source and receivers are relative to the ground
-    protected boolean receiverHasAbsoluteZCoordinates = false;
-    protected boolean sourceHasAbsoluteZCoordinates = false;
+    /** True if Z of receivers geometry is the altitude (sea level) or false if Z is relative to the ground (relative to digital elevation model)
+     * When the propagation area will be prepared. All coordinates will be converted into altitude if necessary.
+     */
+    protected boolean receiverHasSeaLevelZCoordinates = false;
+    /** True if Z of sources geometry is the altitude (sea level) or false if Z is relative to the ground (relative to digital elevation model)
+     *  When the propagation area will be prepared. All coordinates will be converted into altitude if necessary.
+     */
+    protected boolean sourceHasSeaLevelZCoordinates = false;
     protected double maximumPropagationDistance = 750;
     protected double maximumReflectionDistance = 100;
     protected double gs = 0;
@@ -228,7 +229,7 @@ public abstract class GridMapMaker {
      * @return True if provided Z value are sea level (false for relative to ground level)
      */
     public boolean isReceiverHasAbsoluteZCoordinates() {
-        return receiverHasAbsoluteZCoordinates;
+        return receiverHasSeaLevelZCoordinates;
     }
 
     /**
@@ -236,21 +237,21 @@ public abstract class GridMapMaker {
      * @param receiverHasAbsoluteZCoordinates True if provided Z value are sea level (false for relative to ground level)
      */
     public void setReceiverHasAbsoluteZCoordinates(boolean receiverHasAbsoluteZCoordinates) {
-        this.receiverHasAbsoluteZCoordinates = receiverHasAbsoluteZCoordinates;
+        this.receiverHasSeaLevelZCoordinates = receiverHasAbsoluteZCoordinates;
     }
 
     /**
      * @return True if provided Z value are sea level (false for relative to ground level)
      */
     public boolean isSourceHasAbsoluteZCoordinates() {
-        return sourceHasAbsoluteZCoordinates;
+        return sourceHasSeaLevelZCoordinates;
     }
 
     /**
      * @param sourceHasAbsoluteZCoordinates True if provided Z value are sea level (false for relative to ground level)
      */
     public void setSourceHasAbsoluteZCoordinates(boolean sourceHasAbsoluteZCoordinates) {
-        this.sourceHasAbsoluteZCoordinates = sourceHasAbsoluteZCoordinates;
+        this.sourceHasSeaLevelZCoordinates = sourceHasAbsoluteZCoordinates;
     }
 
     public boolean iszBuildings() {

--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/NoiseMapByReceiverMaker.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/NoiseMapByReceiverMaker.java
@@ -309,14 +309,6 @@ public class NoiseMapByReceiverMaker extends GridMapMaker {
             computeRays.setThreadCount(threadCount);
         }
 
-        if(!receiverHasAbsoluteZCoordinates) {
-            computeRays.makeReceiverRelativeZToAbsolute();
-        }
-
-        if(!sourceHasAbsoluteZCoordinates) {
-            computeRays.makeSourceRelativeZToAbsolute();
-        }
-
         computeRays.run(computeRaysOut);
 
         return computeRaysOut;

--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/input/DefaultTableLoader.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/input/DefaultTableLoader.java
@@ -316,6 +316,9 @@ public class DefaultTableLoader implements NoiseMapByReceiverMaker.TableLoader {
                                     " contain at least one receiver without Z ordinate." +
                                     " You must specify X,Y,Z for each receiver");
                         }
+                        if(!noiseMapByReceiverMaker.isReceiverHasAbsoluteZCoordinates()) {
+                            pt = scene.profileBuilder.makeGeometryRelativeZToAbsolute(pt, true);
+                        }
                         scene.addReceiver(receiverPk, pt.getCoordinate(), rs);
                     }
                 }
@@ -741,6 +744,13 @@ public class DefaultTableLoader implements NoiseMapByReceiverMaker.TableLoader {
                                     throw new IllegalArgumentException("The table " + sourcesTableName +
                                             " contain at least one source without Z ordinate." +
                                             " You must specify X,Y,Z for each source");
+                                }
+                            }
+                            if(!noiseMapByReceiverMaker.isSourceHasAbsoluteZCoordinates()) {
+                                if(scene.profileBuilder.hasDem()) {
+                                    // Coordinates are supposed to be relative to the digital elevation model
+                                    // So we must compute the altitude values
+                                    geo = scene.profileBuilder.makeGeometryRelativeZToAbsolute(geo, true);
                                 }
                             }
                             scene.addSource(rs.getLong(pkIndex), geo, rs);

--- a/noisemodelling-jdbc/src/test/java/org/noise_planet/noisemodelling/jdbc/NoiseMapByReceiverMakerTest.java
+++ b/noisemodelling-jdbc/src/test/java/org/noise_planet/noisemodelling/jdbc/NoiseMapByReceiverMakerTest.java
@@ -31,6 +31,7 @@ import org.noise_planet.noisemodelling.propagation.AttenuationParameters;
 import org.noise_planet.noisemodelling.propagation.cnossos.CnossosPath;
 import org.noise_planet.noisemodelling.pathfinder.profilebuilder.GroundAbsorption;
 import org.noise_planet.noisemodelling.pathfinder.utils.geometry.Orientation;
+import org.noise_planet.noisemodelling.propagation.cnossos.PointPath;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -469,11 +470,11 @@ public class NoiseMapByReceiverMakerTest {
 
 
     /**
-     * Place a point source into a building to check if the source is ignored
+     * Place a point source into a building to check if the source is still computed but a warning will be logged
      * @throws Exception
      */
     @Test
-    public void testIgnoredSourceInBuilding() throws Exception {
+    public void testSourceInBuilding() throws Exception {
         try (Statement st = connection.createStatement()) {
             // Import shape file
             // org/noise_planet/noisemodelling/jdbc/PointSource/DEM_Fence.shp
@@ -520,7 +521,12 @@ public class NoiseMapByReceiverMakerTest {
                     pathsParameters.add(cnossosPath);
                 }
             }
-            assertEquals(0 , pathsParameters.size());
+            // Diffraction over the walls of the building, but no direct path
+            assertEquals(2 , pathsParameters.size());
+            // Homogenous path with diffraction over the building wall
+            assertEquals(PointPath.POINT_TYPE.DIFH, pathsParameters.get(0).getPointList().get(1).type);
+            // Favorable path with diffraction over the building wall
+            assertEquals(PointPath.POINT_TYPE.DIFH, pathsParameters.get(1).getPointList().get(1).type);
         }
     }
 }

--- a/noisemodelling-jdbc/src/test/java/org/noise_planet/noisemodelling/jdbc/SceneWithEmissionTest.java
+++ b/noisemodelling-jdbc/src/test/java/org/noise_planet/noisemodelling/jdbc/SceneWithEmissionTest.java
@@ -187,18 +187,15 @@ public class SceneWithEmissionTest {
         double[] roadLvl = AcousticIndicatorsFunctions.dBToW(new double[]{25.65, 38.15, 54.35, 60.35, 74.65, 66.75, 59.25, 53.95});
 
         SceneWithEmission scene = new SceneWithEmission(builder);
-        scene.addReceiver(new Coordinate(50, 50, 0.05));
-        scene.addReceiver(new Coordinate(48, 50, 4));
-        scene.addReceiver(new Coordinate(44, 50, 4));
-        scene.addReceiver(new Coordinate(40, 50, 4));
-        scene.addReceiver(new Coordinate(20, 50, 4));
-        scene.addReceiver(new Coordinate(0, 50, 4));
+        scene.addReceiver(scene.profileBuilder.offsetCoordinatesToAltitudeUsingDigitalElevationModel(
+                new Coordinate[]{new Coordinate(50, 50, 0.05), new Coordinate(48, 50, 4), new Coordinate(44, 50, 4),
+                        new Coordinate(40, 50, 4), new Coordinate(20, 50, 4), new Coordinate(0, 50, 4)}, false));
 
         List<Coordinate> srcPtsRef = new ArrayList<>();
         PathFinder.splitLineStringIntoPoints(geomSource, 1.0, srcPtsRef);
         for (long i = 0; i < srcPtsRef.size(); i++) {
             Coordinate srcPtRef = srcPtsRef.get((int) i);
-            scene.addSource(i, factory.createPoint(srcPtRef));
+            scene.addSource(i, scene.profileBuilder.makeGeometryRelativeZToAbsolute(factory.createPoint(srcPtRef), false));
             scene.addSourceEmission(i, "", roadLvl);
         }
 
@@ -213,7 +210,6 @@ public class SceneWithEmissionTest {
         AttenuationOutputMultiThread propDataOut = new AttenuationOutputMultiThread(scene);
 
         PathFinder computeRays = new PathFinder(scene);
-        computeRays.makeRelativeZToAbsolute();
         computeRays.setThreadCount(1);
         computeRays.run(propDataOut);
 

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
@@ -24,10 +24,8 @@ import org.noise_planet.noisemodelling.pathfinder.path.*;
 import org.noise_planet.noisemodelling.pathfinder.path.MirrorReceiversCompute;
 import org.noise_planet.noisemodelling.pathfinder.path.MirrorReceiver;
 import org.noise_planet.noisemodelling.pathfinder.profilebuilder.*;
-import org.noise_planet.noisemodelling.pathfinder.utils.geometry.CurvedProfileGenerator;
 import org.noise_planet.noisemodelling.pathfinder.utils.geometry.Orientation;
 import org.noise_planet.noisemodelling.pathfinder.utils.geometry.JTSUtility;
-import org.noise_planet.noisemodelling.pathfinder.utils.geometry.QueryRTree;
 import org.noise_planet.noisemodelling.pathfinder.utils.profiler.ProfilerThread;
 import org.noise_planet.noisemodelling.pathfinder.utils.profiler.ReceiverStatsMetric;
 import org.slf4j.Logger;
@@ -42,7 +40,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.lang.Double.isNaN;
 import static java.lang.Math.*;
 import static org.noise_planet.noisemodelling.pathfinder.PathFinder.ComputationSide.LEFT;
-import static org.noise_planet.noisemodelling.pathfinder.PathFinder.ComputationSide.RIGHT;
 
 /**
  * @author Nicolas Fortin
@@ -896,110 +893,6 @@ public class PathFinder {
         }
     }
 
-
-    /**
-     * Apply a linestring over the digital elevation model by offsetting the z value with the ground elevation.
-     * @param lineString
-     * @param profileBuilder
-     * @param epsilon ignore elevation point where linear interpolation distance is inferior that this value
-     * @return computed lineString
-     */
-    private static LineString splitLineSource(LineString lineString, ProfileBuilder profileBuilder, double epsilon) {
-        boolean warned = false;
-        ArrayList<Coordinate> newGeomCoordinates = new ArrayList<>();
-        Coordinate[] coordinates = lineString.getCoordinates();
-        for(int idPoint = 0; idPoint < coordinates.length - 1; idPoint++) {
-            Coordinate p0 = coordinates[idPoint];
-            Coordinate p1 = coordinates[idPoint + 1];
-            List<Coordinate> groundProfileCoordinates = new ArrayList<>();
-            profileBuilder.fetchTopographicProfile(groundProfileCoordinates, p0, p1, false);
-            newGeomCoordinates.ensureCapacity(newGeomCoordinates.size() + groundProfileCoordinates.size());
-            if(groundProfileCoordinates.size() < 2) {
-                if(profileBuilder.hasDem()) {
-                    if(!warned) {
-                        LOGGER.warn( "Source line out of DEM area {}",
-                                new WKTWriter(3).write(lineString));
-                        warned = true;
-                    }
-                }
-                newGeomCoordinates.add(p0);
-                newGeomCoordinates.add(p1);
-            } else {
-                if (idPoint == 0) {
-                    newGeomCoordinates.add(new Coordinate(p0.x, p0.y, p0.z + groundProfileCoordinates.get(0).z));
-                }
-                Coordinate previous = groundProfileCoordinates.get(0);
-                for (int groundPoint = 1; groundPoint < groundProfileCoordinates.size() - 1; groundPoint++) {
-                    final Coordinate current = groundProfileCoordinates.get(groundPoint);
-                    final Coordinate next = groundProfileCoordinates.get(groundPoint + 1);
-                    // Do not add topographic points which are simply the linear interpolation between two points
-                    // triangulation add a lot of interpolated lines from line segment DEM
-                    if (CGAlgorithms3D.distancePointSegment(current, previous, next) >= epsilon) {
-                        // interpolate the Z (height) values of the source then add the altitude
-                        previous = current;
-                        newGeomCoordinates.add(
-                                new Coordinate(current.x, current.y, current.z + Vertex.interpolateZ(current, p0, p1)));
-                    }
-                }
-                newGeomCoordinates.add(new Coordinate(p1.x, p1.y, p1.z +
-                        groundProfileCoordinates.get(groundProfileCoordinates.size() - 1).z));
-            }
-        }
-        return GEOMETRY_FACTORY.createLineString(newGeomCoordinates.toArray(new Coordinate[0]));
-    }
-
-    /**
-     * Update ground Z coordinates of sound sources absolute to sea levels
-     */
-    public void makeSourceRelativeZToAbsolute() {
-        List<Geometry> sourceCopy = new ArrayList<>(data.sourceGeometries.size());
-        for (Geometry source : data.sourceGeometries) {
-            Geometry offsetGeometry;
-            if (source instanceof LineString) {
-                offsetGeometry = splitLineSource((LineString) source, data.profileBuilder, ProfileBuilder.MILLIMETER);
-            } else if (source instanceof MultiLineString) {
-                LineString[] newGeom = new LineString[source.getNumGeometries()];
-                for (int idGeom = 0; idGeom < source.getNumGeometries(); idGeom++) {
-                    newGeom[idGeom] = splitLineSource((LineString) source.getGeometryN(idGeom),
-                            data.profileBuilder, ProfileBuilder.MILLIMETER);
-                }
-                offsetGeometry = GEOMETRY_FACTORY.createMultiLineString(newGeom);
-            } else if (source instanceof Point) {
-                Coordinate sourceCoord = source.getCoordinate();
-                offsetGeometry = GEOMETRY_FACTORY.createPoint(new Coordinate(sourceCoord.x, sourceCoord.y,
-                        sourceCoord.z + data.profileBuilder.getZGround(sourceCoord)));
-                // Check if the source is into a building
-                Building building = data.profileBuilder.getBuildingAtCoordinate(sourceCoord);
-                if(building != null && building.getHeight() >= sourceCoord.z) {
-                    LOGGER.warn("Point source has been ignored as it is inside a building (building height {} m), it should be moved higher SOURCE: {}",
-                            building.getHeight(),new WKTWriter(3).write(source));
-                    continue;
-                }
-            } else {
-                throw new IllegalArgumentException("Unsupported source geometry " + source.getGeometryType());
-            }
-            // Offset the geometry with value of elevation for each coordinate
-            sourceCopy.add(offsetGeometry);
-        }
-        data.setSources(sourceCopy);
-    }
-
-    /**
-     * Update ground Z coordinates of sound sources and receivers absolute to sea levels
-     */
-    public void makeRelativeZToAbsolute() {
-        makeSourceRelativeZToAbsolute();
-        makeReceiverRelativeZToAbsolute();
-    }
-
-    /**
-     * Update ground Z coordinates of receivers absolute to sea levels
-     */
-    public void makeReceiverRelativeZToAbsolute() {
-        for(Coordinate receiver : data.receivers) {
-            receiver.setZ(receiver.getZ() + data.profileBuilder.getZGround(receiver));
-        }
-    }
 
     /**
      * Compute li to equation 4.1 NMPB 2008 (June 2009)

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/path/Scene.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/path/Scene.java
@@ -122,19 +122,6 @@ public class Scene {
     }
 
     /**
-     * Replace the sources by the given list
-     * @param sourceGeometries
-     */
-    public void setSources(List<Geometry> sourceGeometries) {
-        sourcesIndex = new QueryRTree();
-        int i = 0;
-        for(Geometry source : sourceGeometries) {
-            sourcesIndex.appendGeometry(source, i++);
-        }
-        this.sourceGeometries = sourceGeometries;
-    }
-
-    /**
      *
      * @param receiver
      */

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/ProfileBuilder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/ProfileBuilder.java
@@ -13,6 +13,7 @@ import org.locationtech.jts.algorithm.Angle;
 import org.locationtech.jts.algorithm.CGAlgorithms3D;
 import org.locationtech.jts.geom.*;
 import org.locationtech.jts.index.strtree.STRtree;
+import org.locationtech.jts.io.WKTWriter;
 import org.locationtech.jts.math.Vector2D;
 import org.locationtech.jts.math.Vector3D;
 import org.locationtech.jts.operation.distance.DistanceOp;
@@ -282,6 +283,131 @@ public class ProfileBuilder {
         return addBuilding(coords, height, new ArrayList<>(), id);
     }
 
+
+    /**
+     * Apply a linestring over the digital elevation model by offsetting the z value with the ground elevation.
+     * @param lineString
+     * @param epsilon ignore elevation point where linear interpolation distance is inferior that this value
+     * @return computed lineString
+     */
+    public LineString splitGeometryLineToDem(LineString lineString, double epsilon) {
+        boolean warned = false;
+        ArrayList<Coordinate> newGeomCoordinates = new ArrayList<>();
+        Coordinate[] coordinates = lineString.getCoordinates();
+        for(int idPoint = 0; idPoint < coordinates.length - 1; idPoint++) {
+            Coordinate p0 = coordinates[idPoint];
+            Coordinate p1 = coordinates[idPoint + 1];
+            List<Coordinate> groundProfileCoordinates = new ArrayList<>();
+            fetchTopographicProfile(groundProfileCoordinates, p0, p1, false);
+            newGeomCoordinates.ensureCapacity(newGeomCoordinates.size() + groundProfileCoordinates.size());
+            if(groundProfileCoordinates.size() < 2) {
+                if(hasDem()) {
+                    if(!warned) {
+                        LOGGER.warn( "Source line out of DEM area {}",
+                                new WKTWriter(3).write(lineString));
+                        warned = true;
+                    }
+                }
+                newGeomCoordinates.add(p0);
+                newGeomCoordinates.add(p1);
+            } else {
+                if (idPoint == 0) {
+                    newGeomCoordinates.add(new Coordinate(p0.x, p0.y, p0.z + groundProfileCoordinates.get(0).z));
+                }
+                Coordinate previous = groundProfileCoordinates.get(0);
+                for (int groundPoint = 1; groundPoint < groundProfileCoordinates.size() - 1; groundPoint++) {
+                    final Coordinate current = groundProfileCoordinates.get(groundPoint);
+                    final Coordinate next = groundProfileCoordinates.get(groundPoint + 1);
+                    // Do not add topographic points which are simply the linear interpolation between two points
+                    // triangulation add a lot of interpolated lines from line segment DEM
+                    if (CGAlgorithms3D.distancePointSegment(current, previous, next) >= epsilon) {
+                        // interpolate the Z (height) values of the source then add the altitude
+                        previous = current;
+                        newGeomCoordinates.add(
+                                new Coordinate(current.x, current.y, current.z + Vertex.interpolateZ(current, p0, p1)));
+                    }
+                }
+                newGeomCoordinates.add(new Coordinate(p1.x, p1.y, p1.z +
+                        groundProfileCoordinates.get(groundProfileCoordinates.size() - 1).z));
+            }
+        }
+        return lineString.getFactory().createLineString(newGeomCoordinates.toArray(new Coordinate[0]));
+    }
+
+    /**
+     * Update ground Z coordinates of sound sources absolute to sea levels
+     * @param geometry Geometry to offset the Z value
+     * @param checkForBuildingVolumes If true, this function will print a warning if the geometry contain at least one point under a building roof
+     */
+    public Geometry makeGeometryRelativeZToAbsolute(Geometry geometry, boolean checkForBuildingVolumes) {
+        Geometry offsetGeometry;
+        if (geometry instanceof LineString) {
+            offsetGeometry = splitGeometryLineToDem((LineString) geometry, ProfileBuilder.MILLIMETER);
+            if (checkForBuildingVolumes) {
+                Coordinate[] coordinates = offsetGeometry.getCoordinates();
+                logWarningIfCoordinatesIntoBuildings(coordinates);
+            }
+        } else if (geometry instanceof MultiLineString) {
+            LineString[] newGeom = new LineString[geometry.getNumGeometries()];
+            for (int idGeom = 0; idGeom < geometry.getNumGeometries(); idGeom++) {
+                newGeom[idGeom] = splitGeometryLineToDem((LineString) geometry.getGeometryN(idGeom),
+                        MILLIMETER);
+            }
+            offsetGeometry = geometry.getFactory().createMultiLineString(newGeom);
+            if (checkForBuildingVolumes) {
+                Coordinate[] coordinates = offsetGeometry.getCoordinates();
+                logWarningIfCoordinatesIntoBuildings(coordinates);
+            }
+        } else if (geometry instanceof Point) {
+            Coordinate geometryCoordinate = geometry.getCoordinate();
+            offsetGeometry = geometry.getFactory().createPoint(offsetCoordinateToAltitudeUsingDigitalElevationModel(geometryCoordinate, checkForBuildingVolumes));
+        } else {
+            throw new IllegalArgumentException("Unsupported source geometry " + geometry.getGeometryType());
+        }
+        return offsetGeometry;
+    }
+
+    /**
+     * Update ground Z coordinates of sound sources absolute to sea levels
+     * @param geometryCoordinates Geometry coordinates to offset the Z value
+     * @param checkForBuildingVolumes If true, this function will print a warning if the geometry contain at least one point under a building roof
+     */
+    public Coordinate[] offsetCoordinatesToAltitudeUsingDigitalElevationModel(Coordinate[] geometryCoordinates, boolean checkForBuildingVolumes) {
+        Coordinate[] offsetCoordinates = new Coordinate[geometryCoordinates.length];
+        for (int i = 0; i < geometryCoordinates.length; i++) {
+            offsetCoordinates[i] = offsetCoordinateToAltitudeUsingDigitalElevationModel(geometryCoordinates[i], checkForBuildingVolumes);
+        }
+        return offsetCoordinates;
+    }
+
+    /**
+     * Offset a coordinate to altitude using the digital elevation model. The Z value of the coordinate is updated with the ground elevation at this point.
+     * @param geometryCoordinate Coordinate to offset
+     * @param checkForBuildingVolumes If true, this function will print a warning if the geometry contain at least one point under a building roof
+     * @return
+     */
+    public Coordinate offsetCoordinateToAltitudeUsingDigitalElevationModel(Coordinate geometryCoordinate, boolean checkForBuildingVolumes) {
+        Coordinate offsetCoordinate = new Coordinate(geometryCoordinate.x, geometryCoordinate.y, geometryCoordinate.z + getZGround(geometryCoordinate));
+        if(checkForBuildingVolumes) {
+            logWarningIfCoordinatesIntoBuildings(geometryCoordinate);
+        }
+        return offsetCoordinate;
+    }
+
+    private void logWarningIfCoordinatesIntoBuildings(Coordinate... coordinates) {
+        for (Coordinate coordinate : coordinates) {
+            // Check if the source is into a building
+            Building building = getBuildingAtCoordinate(coordinate);
+            if (building != null && building.getHeight() >= coordinate.z) {
+                LOGGER.warn("Geometry (Source point or Receiver point) has been defined inside a building" +
+                                " (building height {} m), it should be moved higher Geometry: {}",
+                        building.getHeight(), new WKTWriter(3).write(new GeometryFactory().createPoint(coordinate)));
+                break;
+            }
+        }
+    }
+
+
     /**
      * Add the given {@link Geometry} footprint, height and alphas (absorption coefficients) as building.
      * @param geom   Building footprint.
@@ -397,15 +523,6 @@ public class ProfileBuilder {
     public ProfileBuilder addWall(Coordinate[] coords, double height, int id) {
         return addWall(FACTORY.createLineString(coords), height, new ArrayList<>(), id);
     }
-
-    /**
-     * Add the given {@link Geometry} footprint, height, alphas (absorption coefficients) and a database id as wall.
-     * @param geom   Wall footprint.
-     * @param id     Database key.
-     */
-    /*public ProfileBuilder addWall(LineString geom, int id) {
-        return addWall(geom, 0.0, new ArrayList<>(), id);
-    }*/
 
     /**
      * Add the given {@link Geometry} footprint, height, alphas (absorption coefficients) and a database id as wall.

--- a/noisemodelling-pathfinder/src/test/java/org/noise_planet/noisemodelling/pathfinder/ProfileBuilderTest.java
+++ b/noisemodelling-pathfinder/src/test/java/org/noise_planet/noisemodelling/pathfinder/ProfileBuilderTest.java
@@ -286,10 +286,8 @@ public class ProfileBuilderTest {
         Scene scene = new Scene(profileBuilder);
         WKTReader wktReader = new WKTReader();
         Geometry geometry = wktReader.read("MultiLineStringZ ((10 10 1, 200 50 1))");
-        scene.addSource(1L, geometry);
-        PathFinder pathFinder = new PathFinder(scene);
-        assertEquals(2, scene.sourceGeometries.get(0).getNumPoints());
-        pathFinder.makeSourceRelativeZToAbsolute();
+        scene.addSource(1L, profileBuilder.makeGeometryRelativeZToAbsolute(geometry, false));
+        assertEquals(2, geometry.getNumPoints());
         // The source line should now be made of 4 points (2 points being created by the elevated DEM)
         assertEquals(4, scene.sourceGeometries.get(0).getNumPoints());
         List<Coordinate> expectedProfile = Arrays.asList(


### PR DESCRIPTION
A recent update was removing the sound source without updating the shift in primary key of sound sources resulting in erroneous computation. Now the sound source is kept but a warning is logged with the location of the source source or receiver point.

#822 