### PR TITLE
Implement concurrency for CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   build_linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add concurrency configuration to CI workflow to cancel the github action if a new commit has been done since in the pull request (save resources)