### PR TITLE
Add lineSourceSpacingRatio as param of Noise_level_from_source script

### DIFF
--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/NoiseModelling/Noise_level_from_source.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/NoiseModelling/Noise_level_from_source.groovy
@@ -266,6 +266,13 @@ inputs = [
                 description: 'Frequency field name prepend. Ex. for 1000 Hz frequency the default column name is HZ1000.',
                 default    : 'HZ',
                 type: String.class
+        ],
+        confLineSourceSpacingRatio: [
+                name       : 'Line source spacing ratio',
+                title      : 'Line source spacing ratio',
+                description: 'Dictates the density of source points created from a line sound source. A higher value means more points and finer discretization.',
+                default    : 2.0,
+                type       : Double.class
         ]
 ]
 
@@ -432,6 +439,11 @@ def exec(Connection connection, Map input, ProgressVisitor progress) {
         frequencyFieldPrepend = input['frequencyFieldPrepend'] as String
     }
 
+    double confLineSourceSpacingRatio = input.getOrDefault("confLineSourceSpacingRatio", 2.0) as Double
+    if (confLineSourceSpacingRatio <= 0) {
+        throw new IllegalArgumentException("Error : confLineSourceSpacingRatio must be greater than 0.")
+    }
+
     // --------------------------------------------
     // Initialize NoiseModelling propagation part
     // --------------------------------------------
@@ -479,6 +491,7 @@ def exec(Connection connection, Map input, ProgressVisitor progress) {
     pointNoiseMap.setComputeVerticalDiffraction(compute_horizontal_diffraction)
     pointNoiseMap.setSoundReflectionOrder(reflexion_order)
     pointNoiseMap.setFrequencyFieldPrepend(frequencyFieldPrepend)
+    pointNoiseMap.getSceneInputSettings().setLineSourceSpacingRatio(confLineSourceSpacingRatio)
 
 
     // Set environmental parameters

--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/NoiseModelling/Noise_level_from_source.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/NoiseModelling/Noise_level_from_source.groovy
@@ -270,7 +270,7 @@ inputs = [
         confLineSourceSpacingRatio: [
                 name       : 'Line source spacing ratio',
                 title      : 'Line source spacing ratio',
-                description: 'Dictates the density of source points created from a line sound source. A higher value means more points and finer discretization.',
+                description: 'Dictates the density of source points created from a line sound source. A higher value means more points and finer discretization : DistanceBetweenPoints = DistanceSourceToReceiver / LineSourceSpacingRatio (this parameter)',
                 default    : 2.0,
                 type       : Double.class
         ]

--- a/noisemodelling-scripts/src/test/groovy/org/noise_planet/noisemodelling/scripts/TestNoiseModelling.groovy
+++ b/noisemodelling-scripts/src/test/groovy/org/noise_planet/noisemodelling/scripts/TestNoiseModelling.groovy
@@ -383,7 +383,7 @@ class TestNoiseModelling extends JdbcTestCase {
         assertTrue(JDBCUtilities.tableExists(connection, RAYS_TABLE))
         int raysCount = sql.firstRow("SELECT COUNT(*) CPT FROM " + RAYS_TABLE)["CPT"] as Integer
         LOGGER.info("number or rays with confLineSourceSpacingRatio = " + LINE_SOURCE_RATIO + " : " + raysCount)
-        assertTrue(raysCount == EXPECTED_NB_RAYS)
+        assertEquals(raysCount, EXPECTED_NB_RAYS)
     }
 
 }

--- a/noisemodelling-scripts/src/test/groovy/org/noise_planet/noisemodelling/scripts/TestNoiseModelling.groovy
+++ b/noisemodelling-scripts/src/test/groovy/org/noise_planet/noisemodelling/scripts/TestNoiseModelling.groovy
@@ -347,7 +347,11 @@ class TestNoiseModelling extends JdbcTestCase {
     }
 
     @Test
-    void testLineSourceSpacingRatioIncreasesEmitterCountInSimulation() {
+    void testRaysTableAndLineSourceSpacingRatio() {
+        String RAYS_TABLE = "RAYS"
+        Double LINE_SOURCE_RATIO = 4.0
+        Integer EXPECTED_NB_RAYS = 125716
+
         new Import_File().exec(connection,
                 ["pathFile" : TestNoiseModelling.getResource("ROADS2.shp").getPath()])
 
@@ -370,27 +374,16 @@ class TestNoiseModelling extends JdbcTestCase {
                 ["tableBuilding"             : "BUILDINGS",
                  "tableSources"              : "LW_ROADS",
                  "tableReceivers"            : "RECEIVERS",
-                 "confRaysName"              : "RAYS_DEFAULT_RATIO",
-                 "confLineSourceSpacingRatio": 2.0d,
+                 "confRaysName"              : RAYS_TABLE,
+                 "confLineSourceSpacingRatio": LINE_SOURCE_RATIO,
                  "confReflOrder"             : 0,
                  "confDiffVertical"          : false,
                  "confDiffHorizontal"        : false])
 
-        int defaultEmitterCount = sql.firstRow("SELECT COUNT(*) CPT FROM RAYS_DEFAULT_RATIO")["CPT"] as Integer
-
-        new Noise_level_from_source().exec(connection,
-                ["tableBuilding"             : "BUILDINGS",
-                 "tableSources"              : "LW_ROADS",
-                 "tableReceivers"            : "RECEIVERS",
-                 "confRaysName"              : "RAYS_HIGH_RATIO",
-                 "confLineSourceSpacingRatio": 8.0d,
-                 "confReflOrder"             : 0,
-                 "confDiffVertical"          : false,
-                 "confDiffHorizontal"        : false])
-
-        int highRatioEmitterCount = sql.firstRow("SELECT COUNT(*) CPT FROM RAYS_HIGH_RATIO")["CPT"] as Integer
-
-        assertTrue(highRatioEmitterCount > defaultEmitterCount)
+        assertTrue(JDBCUtilities.tableExists(connection, RAYS_TABLE))
+        int raysCount = sql.firstRow("SELECT COUNT(*) CPT FROM " + RAYS_TABLE)["CPT"] as Integer
+        LOGGER.info("number or rays with confLineSourceSpacingRatio = " + LINE_SOURCE_RATIO + " : " + raysCount)
+        assertTrue(raysCount == EXPECTED_NB_RAYS)
     }
 
 }

--- a/noisemodelling-scripts/src/test/groovy/org/noise_planet/noisemodelling/scripts/TestNoiseModelling.groovy
+++ b/noisemodelling-scripts/src/test/groovy/org/noise_planet/noisemodelling/scripts/TestNoiseModelling.groovy
@@ -345,4 +345,52 @@ class TestNoiseModelling extends JdbcTestCase {
             assertEquals(receiverCount, periodCount)
         }
     }
+
+    @Test
+    void testLineSourceSpacingRatioIncreasesEmitterCountInSimulation() {
+        new Import_File().exec(connection,
+                ["pathFile" : TestNoiseModelling.getResource("ROADS2.shp").getPath()])
+
+        new Road_Emission_from_Traffic().exec(connection,
+                ["tableRoads": "ROADS2"])
+
+        new Import_File().exec(connection,
+                ["pathFile" : TestNoiseModelling.getResource("buildings.shp").getPath(),
+                 "inputSRID": "2154",
+                 "tableName": "buildings"])
+
+        new Import_File().exec(connection,
+                ["pathFile" : TestNoiseModelling.getResource("receivers.shp").getPath(),
+                 "inputSRID": "2154",
+                 "tableName": "receivers"])
+
+        Sql sql = new Sql(connection)
+
+        new Noise_level_from_source().exec(connection,
+                ["tableBuilding"             : "BUILDINGS",
+                 "tableSources"              : "LW_ROADS",
+                 "tableReceivers"            : "RECEIVERS",
+                 "confRaysName"              : "RAYS_DEFAULT_RATIO",
+                 "confLineSourceSpacingRatio": 2.0d,
+                 "confReflOrder"             : 0,
+                 "confDiffVertical"          : false,
+                 "confDiffHorizontal"        : false])
+
+        int defaultEmitterCount = sql.firstRow("SELECT COUNT(*) CPT FROM RAYS_DEFAULT_RATIO")["CPT"] as Integer
+
+        new Noise_level_from_source().exec(connection,
+                ["tableBuilding"             : "BUILDINGS",
+                 "tableSources"              : "LW_ROADS",
+                 "tableReceivers"            : "RECEIVERS",
+                 "confRaysName"              : "RAYS_HIGH_RATIO",
+                 "confLineSourceSpacingRatio": 8.0d,
+                 "confReflOrder"             : 0,
+                 "confDiffVertical"          : false,
+                 "confDiffHorizontal"        : false])
+
+        int highRatioEmitterCount = sql.firstRow("SELECT COUNT(*) CPT FROM RAYS_HIGH_RATIO")["CPT"] as Integer
+
+        assertTrue(highRatioEmitterCount > defaultEmitterCount)
+    }
+
 }


### PR DESCRIPTION
I exposed the lineSourceSpacingRatio param in the Noise_level_from_source.groovy script. This allows the user to define the density of emitters along the roads.