### PR TITLE
Force local dtd validation on matsim

### DIFF
--- a/Docs/functions/NoiseModelling/Noise_level_from_source.rst
+++ b/Docs/functions/NoiseModelling/Noise_level_from_source.rst
@@ -117,6 +117,13 @@ Optional inputs
 
    Default: ``70``
 
+``confLineSourceSpacingRatio`` — *Line source spacing ratio*
+   Dictates the density of source points created from a line sound source. A higher value means more points and finer discretization : DistanceBetweenPoints = DistanceSourceToReceiver / LineSourceSpacingRatio (this parameter)
+
+   Type: ``Double``
+
+   Default: ``2.0``
+
 ``confMaxError`` — *Max Error (dB)*
    Threshold for excluding negligible sound sources in calculations.This parameter is ignored if no emission level is specified or if you set it to 0 dB. This parameter have a great impact on computation time.
 

--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Experimental_Matsim/Traffic_From_Events.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Experimental_Matsim/Traffic_From_Events.groovy
@@ -295,7 +295,9 @@ static def exec(Connection connection, Map input) {
 
     Network network = scenario.getNetwork()
     MatsimNetworkReader networkReader = new MatsimNetworkReader(network)
+    // Fix issue with DTD located on matsim website
     networkReader.setValidating(false)
+    System.setProperty("matsim.preferLocalDtds", "true")
     logger.info("Start reading network file ... ")
     networkReader.readFile(networkFile)
     logger.info("Done reading network file ")


### PR DESCRIPTION
Did not update matsim to 2026 as it requires running Java 25

matsim use a lot of this system variable in the tests:

https://github.com/search?q=repo%3Amatsim-org%2Fmatsim-libs%20matsim.preferLocalDtds&type=code