### PR TITLE
Update matsim and set noisemodelling require running at least java 25

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       # Setup the jdk using version 11 of Adoptium Temurin
-      - name: Setup java 11 using Adoptium Temurin
+      - name: Setup java 25 using Adoptium Temurin
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '25'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/CI_Release.yml
+++ b/.github/workflows/CI_Release.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       # Setup the jdk using version 11 of Adoptium Temurin
-      - name: Setup java 11 using Adoptium Temurin
+      - name: Setup java 25 using Adoptium Temurin
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '25'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -57,11 +57,11 @@ jobs:
             $HOME/.m2/
           key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
       # Setup the jdk using version 11 of Adoptium Temurin
-      - name: Setup java 11 using Adoptium Temurin
+      - name: Setup java 25 using Adoptium Temurin
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '25'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
@@ -119,7 +119,7 @@ jobs:
           dir installer\app\bin
       - name: Download Windows JRE (Adoptium)
         run: |
-          $jreUrl = "https://api.adoptium.net/v3/binary/latest/21/ga/windows/x64/jre/hotspot/normal/eclipse"
+          $jreUrl = "https://api.adoptium.net/v3/binary/latest/25/ga/windows/x64/jre/hotspot/normal/eclipse"
           Invoke-WebRequest -Uri $jreUrl -OutFile jre.zip
           Expand-Archive -Path jre.zip -DestinationPath jre_raw -Force
           $innerDir = (Get-ChildItem jre_raw | Where-Object PSIsContainer | Select-Object -First 1).FullName

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use a Maven image that already includes JDK 21
-FROM maven:3.9.9-eclipse-temurin-21 AS builder
+# Use a Maven image that already includes JDK
+FROM maven:3.9.16-eclipse-temurin-25-noble AS builder
 
 # Set working directory
 WORKDIR /build

--- a/Docs/Tutorial_Get_Started_GUI.rst
+++ b/Docs/Tutorial_Get_Started_GUI.rst
@@ -8,8 +8,9 @@ Step 1: Download NoiseModelling
 
 Download the latest release of NoiseModelling on `Github`_.
 
-* Windows: you can directly download and run the ``NoiseModelling_5.x.x_install.exe`` installer file *(or you can also follow the Linux / Mac instructions below)*
-* Linux or Mac: download the ``NoiseModelling_5.x.x.zip`` file and unzip it into a chosen directory
+* Windows: you can directly download and run the ``NoiseModelling_*.exe`` installer file *(or you can also follow the Linux instructions below if you have the :doc:`Tutorial_Requirements`)*
+* MacOS: you can directly download and run the ``NoiseModelling_*.dmg`` installer file *(or you can also follow the Linux instructions below if you have the :doc:`Tutorial_Requirements`)*
+* Linux : download the ``NoiseModelling_6.x.x.zip`` file and unzip it into a chosen directory
 
 .. warning::
     The chosen directory can be anywhere, but make sure you have write access. If you are using a company computer, the Program Files folder is probably not a good idea.
@@ -17,12 +18,7 @@ Download the latest release of NoiseModelling on `Github`_.
 .. warning::
     For **Linux** and **Mac** users, please make sure your Java environment is correctly set up. For more information, please read the page :doc:`Tutorial_Requirements`. **Windows** users who are using the ``.exe`` file are not concerned, since the Java Runtime Environment is **already embedded**.
 
-.. note::
-    Starting from version 3.3, NoiseModelling releases include the user interface described in this tutorial.
-
 .. _Github : https://github.com/Universite-Gustave-Eiffel/NoiseModelling/releases
-
-
 
 Step 2: Start NoiseModelling GUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Docs/Tutorial_Requirements.rst
+++ b/Docs/Tutorial_Requirements.rst
@@ -6,7 +6,7 @@ Java environment
 
 Since NoiseModelling is developed with the `Java langage`_, you will need to install the Java Runtime Environment (JRE) on your computer to use the application.
 
-NoiseModelling requires Java >= 11. Any version of Java 11 or later is supported.
+NoiseModelling requires Java >= 25. Any version of Java 25 or later is supported.
 
 .. _Java langage : https://en.wikipedia.org/wiki/Java_(programming_language)
 

--- a/Docs/Tutorial_Requirements.rst
+++ b/Docs/Tutorial_Requirements.rst
@@ -4,18 +4,18 @@ Requirements
 Java environment
 ~~~~~~~~~~~~~~~~~~~~
 
-Since NoiseModelling is developed with the `Java langage`_, you will need to install the Java Runtime Environment (JRE) on your computer to use the application.
+Since NoiseModelling is developed with the `Java language`_, you will need to install the Java Runtime Environment (JRE) on your computer to use the application.
 
 NoiseModelling requires Java >= 25. Any version of Java 25 or later is supported.
 
-.. _Java langage : https://en.wikipedia.org/wiki/Java_(programming_language)
+.. _Java language : https://en.wikipedia.org/wiki/Java_(programming_language)
 
 Windows
 ----------
 
 If you are launching NoiseModelling thanks to the ``NoiseModelling_xxx_install.exe`` file, the JRE is already inside, so **you don't have anything to do**.
 
-If you are not using the ``.exe`` file, you have to launch NoiseModelling thanks to the ```start_windows.bat`` file (in the ``NoiseModelling_xxx.zip`` release file). In this case, Java >= 11  has to be installed before.
+If you are not using the ``.exe`` file, you have to launch NoiseModelling thanks to the ```start_windows.bat`` file (in the ``NoiseModelling_xxx.zip`` release file). In this case, Java >= 25  has to be installed before.
 
 Download and install Java: choose between `OpenJDK`_ or `Oracle`_ versions.
 
@@ -25,13 +25,13 @@ Download and install Java: choose between `OpenJDK`_ or `Oracle`_ versions.
 Linux or Mac
 -------------
 
-If not already done, you have to install the Java version >= 11.
+If not already done, you have to install the Java version >= 25.
 
 #. Check whether Java is already installed::
 
       java -version
 
-   The command should print a version starting with ``11``. Otherwise, install Java first.
+   The command should print a version starting with ``25``. Otherwise, install Java first.
 
 #. Download and install Java: choose between `OpenJDK`_ or `Oracle`_ versions.
 
@@ -42,8 +42,8 @@ If not already done, you have to install the Java version >= 11.
       readlink -f "$(command -v java)"
 
    This prints a path ending with ``/bin/java`` (for example
-   ``/usr/lib/jvm/java-22-openjdk-amd64/bin/java``); ``JAVA_HOME`` is the parent
-   directory of ``bin`` (here ``/usr/lib/jvm/java-22-openjdk-amd64``).
+   ``/usr/lib/jvm/java-25-openjdk-amd64/bin/java``); ``JAVA_HOME`` is the parent
+   directory of ``bin`` (here ``/usr/lib/jvm/java-25-openjdk-amd64``).
 
    *On macOS*::
 
@@ -54,7 +54,7 @@ If not already done, you have to install the Java version >= 11.
 #. Set the ``JAVA_HOME`` environment variable and update your ``PATH`` (adapt the
    path with the one found above)::
 
-      export JAVA_HOME=/usr/lib/jvm/java-22-openjdk-amd64
+      export JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64
       export PATH="$JAVA_HOME/bin:$PATH"
 
    On macOS you can also use::
@@ -67,7 +67,7 @@ If not already done, you have to install the Java version >= 11.
       echo $JAVA_HOME
 
    You should get the Java directory (for example
-   ``/usr/lib/jvm/java-22-openjdk-amd64``). If this is not the case, you are
+   ``/usr/lib/jvm/java-25-openjdk-amd64``). If this is not the case, you are
    invited to follow the steps `proposed here`_.
 
 .. _proposed here: https://stackoverflow.com/questions/24641536/how-to-set-java-home-in-linux-for-all-users

--- a/noisemodelling-emission/pom.xml
+++ b/noisemodelling-emission/pom.xml
@@ -78,11 +78,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/noisemodelling-jdbc/pom.xml
+++ b/noisemodelling-jdbc/pom.xml
@@ -112,11 +112,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/noisemodelling-pathfinder/pom.xml
+++ b/noisemodelling-pathfinder/pom.xml
@@ -107,11 +107,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/noisemodelling-propagation/pom.xml
+++ b/noisemodelling-propagation/pom.xml
@@ -104,11 +104,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/noisemodelling-scripts/pom.xml
+++ b/noisemodelling-scripts/pom.xml
@@ -551,11 +551,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>25</source>
+                    <target>25</target>
                 </configuration>
             </plugin>
             <!-- Sign -->
@@ -503,7 +503,7 @@
             <dependency>
                 <groupId>org.matsim</groupId>
                 <artifactId>matsim</artifactId>
-                <version>14.0</version>
+                <version>2026.0</version>
             </dependency>
             <!-- Test dependencies -->
             <dependency>


### PR DESCRIPTION
This update may arise some issues with users as it requires using a recent version of java