### PR TITLE
Attach sources with the distribution of NoiseModelling

### DIFF
--- a/noisemodelling-scripts/pom.xml
+++ b/noisemodelling-scripts/pom.xml
@@ -558,14 +558,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
-                        <phase>package</phase>
                     </execution>
                 </executions>
             </plugin>

--- a/noisemodelling-scripts/pom.xml
+++ b/noisemodelling-scripts/pom.xml
@@ -527,6 +527,25 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependency-sources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>sources</classifier>
+                            <failOnMissingClassifierArtifact>false</failOnMissingClassifierArtifact>
+                            <outputDirectory>${project.build.directory}/dependency-sources</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>

--- a/noisemodelling-scripts/src/assembly/distribution.xml
+++ b/noisemodelling-scripts/src/assembly/distribution.xml
@@ -61,5 +61,19 @@
             </includes>
             <fileMode>0755</fileMode>
         </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/dependency-sources</directory>
+            <outputDirectory>lib-src</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}</directory>
+            <outputDirectory>lib-src</outputDirectory>
+            <includes>
+                <include>${project.build.finalName}-sources.jar</include>
+            </includes>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/noisemodelling-scripts/src/assembly/distribution.xml
+++ b/noisemodelling-scripts/src/assembly/distribution.xml
@@ -63,14 +63,14 @@
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}/dependency-sources</directory>
-            <outputDirectory>lib-src</outputDirectory>
+            <outputDirectory>lib</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}</directory>
-            <outputDirectory>lib-src</outputDirectory>
+            <outputDirectory>lib</outputDirectory>
             <includes>
                 <include>${project.build.finalName}-sources.jar</include>
             </includes>


### PR DESCRIPTION
Maven central is collecting the source code of all libraries along with the binary. When creating the assembly of NoiseModelling, create a sub directory with source code, that can be used when creating a new Groovy Block in an IDE

This change add something like 90 mb on the size of the assembly, so I don't know if it is too much ?