### PR TITLE
Check for null primary key instead of index

### DIFF
--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/DelaunayReceiversMaker.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/DelaunayReceiversMaker.java
@@ -496,8 +496,7 @@ public class DelaunayReceiversMaker extends GridMapMaker {
         Geometry domainConstraint = geometryFactory.toGeometry(fetchEnvelope);
         Tuple<String, Integer> primaryKey = JDBCUtilities.getIntegerPrimaryKeyNameAndIndex(
                 connection.unwrap(Connection.class), TableLocation.parse(sourcesTableName, dbType));
-        int pkIndex = primaryKey.second();
-        if (pkIndex < 1) {
+        if (primaryKey == null) {
             throw new IllegalArgumentException(String.format("Source table %s does not contain a primary key", sourceTableIdentifier));
         }
         try (PreparedStatement st = connection.prepareStatement("SELECT * FROM " + sourcesTableName + " WHERE "


### PR DESCRIPTION
When there is no primary key it return null
```
java.lang.NullPointerException: Cannot invoke "org.h2gis.utilities.Tuple.second()" because "primaryKey" is null
	at org.noise_planet.noisemodelling.jdbc.DelaunayReceiversMaker.fetchCellSource(DelaunayReceiversMaker.java:499)
	at org.noise_planet.noisemodelling.jdbc.DelaunayReceiversMaker.generateReceivers(DelaunayReceiversMaker.java:547)
	at org.noise_planet.noisemodelling.jdbc.DelaunayReceiversMaker.run(DelaunayReceiversMaker.java:139)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:344)
	at org.noise_planet.noisemodelling.scripts.Receivers.Delaunay_Grid.exec(Delaunay_Grid.groovy:364)
```