### PR TITLE
Remove reading of Height field in DelaunayGrid

### DIFF
--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Receivers/Delaunay_Grid.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Receivers/Delaunay_Grid.groovy
@@ -361,6 +361,7 @@ def exec(Connection connection, Map input, ProgressVisitor progressLogger) {
 
     long startTime = System.currentTimeMillis()
     try {
+        delaunayReceiversMaker.getBuildingTableParameters().setHeightField("") // This field is not used when creating a delaunay triangulation
         delaunayReceiversMaker.run(connection, receivers_table_name, outputTableNameTriangles, progressLogger)
     } catch (LayerDelaunayError ex) {
         logger.error("Got an error use the errorDumpFolder parameter with a folder path in order to save the " +

--- a/noisemodelling-scripts/src/test/java/org/noise_planet/noisemodelling/scripts/MainTest.java
+++ b/noisemodelling-scripts/src/test/java/org/noise_planet/noisemodelling/scripts/MainTest.java
@@ -24,6 +24,7 @@ import org.noise_planet.noisemodelling.runner.Main;
 import org.noise_planet.noisemodelling.scripts.Database_Manager.Clean_Database;
 import org.noise_planet.noisemodelling.webserver.utilities.Logging;
 
+import javax.sql.DataSource;
 import java.io.File;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -128,7 +129,9 @@ public class MainTest {
         String buildingsPath = MainTest.class.getResource("buildings.shp").getPath();
         String roadsPath = MainTest.class.getResource("ROADS2.shp").getPath();
 
-        try (Connection connection = JdbcTestCase.createPostgisDataSourceFromEnv().getConnection()) {
+        DataSource postgisDataSource = JdbcTestCase.createPostgisDataSourceFromEnv();
+
+        try (Connection connection = postgisDataSource.getConnection()) {
             connection.createStatement().execute("CREATE SCHEMA IF NOT EXISTS TESTDELAUNAY");
             new Clean_Database().exec(connection, Map.of("areYouSure", true, "schema", "testdelaunay"));
             assertFalse(JDBCUtilities.tableExists(connection, "testdelaunay.receivers"), "Table RECEIVERS should not exist in PostGIS");
@@ -143,6 +146,12 @@ public class MainTest {
                 "--host", pgHost,
                 "--pathFile", buildingsPath,
                 "--tableName", "testdelaunay.buildings");
+
+        try(Connection connection = postgisDataSource.getConnection()) {
+            // Remove height field in BUILDINGS table (to check if it is working without this field)
+            connection.createStatement().execute("ALTER TABLE testdelaunay.buildings DROP COLUMN HEIGHT");
+        }
+
 
         Main.main("-w", temp.getAbsolutePath(),
                 "-d", pgDb,
@@ -166,7 +175,7 @@ public class MainTest {
                 "--outputTableName", "testdelaunay.receivers"
                 );
 
-        try (Connection connection = JdbcTestCase.createPostgisDataSourceFromEnv().getConnection()) {
+        try (Connection connection = postgisDataSource.getConnection()) {
             assertTrue(JDBCUtilities.tableExists(connection, "testdelaunay.receivers"), "Table RECEIVERS should exist in PostGIS");
         }
     }


### PR DESCRIPTION
This field is not used by this algorithm so its weird that it is mandatory (need to get rid of it for ech5)