### PR TITLE
Index the IDSOURCE join keys in the dynamic emission workflow

### DIFF
--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Flow_2_Noisy_Vehicles.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Flow_2_Noisy_Vehicles.groovy
@@ -257,7 +257,10 @@ def exec(Connection connection, input) {
             }
         })
     }
-    sql.execute("CREATE INDEX ON SOURCES_EMISSION(PERIOD, IDSOURCE)")
+    // IDSOURCE must be the leading column: both the per-cell emission fetch and the
+    // Noise_From_Attenuation_Matrix join look rows up by IDSOURCE (H2 nested-loop joins
+    // cannot use an index whose leading column is PERIOD for those lookups)
+    sql.execute("CREATE INDEX ON SOURCES_EMISSION(IDSOURCE, PERIOD)")
     sql.execute("drop table VEHICLES_PROBA if exists;")
 
 

--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Noise_From_Attenuation_Matrix.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Noise_From_Attenuation_Matrix.groovy
@@ -109,6 +109,14 @@ def exec(Connection connection, input) {
     String timeString = "PERIOD"
     String prefix = "HZ"
 
+    // H2 executes joins as nested loops with index lookups: without an index whose leading
+    // column is the join key, the join below degenerates to a full scan of one table for
+    // every row of the other one. Index both sides so the planner can pick either join order.
+    String lwTableName = TableLocation.parse(lwTable, dbType).getTable()
+    String attenuationTableName = TableLocation.parse(attenuationTable, dbType).getTable()
+    sql.execute("CREATE INDEX IF NOT EXISTS ${lwTableName}_${lwTable_sourceId}_IDX ON $lwTable ($lwTable_sourceId)".toString())
+    sql.execute("CREATE INDEX IF NOT EXISTS ${attenuationTableName}_IDSOURCE_IDX ON $attenuationTable (IDSOURCE)".toString())
+
     // Groovy Dollar slashy string that contain the queries
 
     def query2 = $/CREATE TABLE $outputTable AS SELECT lg.IDRECEIVER,


### PR DESCRIPTION
H2 executes joins as nested loops with index lookups only: the Noise_From_Attenuation_Matrix join (attenuation matrix x LW table on IDSOURCE) degenerates to a full scan of one table for every row of the other when neither side has an IDSOURCE-leading index. The attenuation table only gets an (IDRECEIVER, IDSOURCE) index from NoiseMapWriter, and Flow_2_Noisy_Vehicles indexed SOURCES_EMISSION as (PERIOD, IDSOURCE) - both unusable for this join.

- Noise_From_Attenuation_Matrix now creates IDSOURCE indexes on both join sides before running the aggregation (works for any input table, H2 and PostGIS).
- Flow_2_Noisy_Vehicles now indexes SOURCES_EMISSION with IDSOURCE as the leading column, which also serves the per-cell emission fetch in DefaultTableLoader.

Synthetic benchmark (in-memory H2GIS, attenuation 100k rows):
- LW 1.6k rows  (S=200, P=8):   8.3 s -> 4.3 s
- LW 24k rows   (S=1000, P=24): 99.0 s -> 10.4 s (~9.5x)
Pre-fix cost grows with |attenuation| x |LW|; fixed cost grows only with the joined row count, so the gap widens further at real dynamic workflow scale. TestDynamic suite passes (5/5).