### PR TITLE
Replace linear source lookup with a map when loading emission rows

### DIFF
--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/input/SceneWithEmission.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/input/SceneWithEmission.java
@@ -62,7 +62,7 @@ public class SceneWithEmission extends SceneWithAttenuation {
         // Use geometry as default slope (if field slope is not provided
         double defaultSlope = 0;
         if(!sourceFieldNames.containsKey("SLOPE")) {
-            int sourceIndex = sourcesPk.indexOf(pk);
+            int sourceIndex = sourcesPkIndex.getOrDefault(pk, -1);
             if(sourceIndex >= 0) {
                 defaultSlope = EmissionTableGenerator.getSlope(sourceGeometries.get(sourceIndex));
             }

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/path/Scene.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/path/Scene.java
@@ -43,6 +43,8 @@ public class Scene {
 
     public List<Long> receiversPk = new ArrayList<>();
     public List<Long> sourcesPk = new ArrayList<>();
+    /** Index of each source primary key in the sourcesPk list */
+    public Map<Long, Integer> sourcesPkIndex = new HashMap<>();
     /** coordinate of receivers */
     public List<Coordinate> receivers = new ArrayList<>();
     /** Profile builder */
@@ -116,6 +118,7 @@ public class Scene {
     public void addSource(Long pk, Geometry geom) {
         addSource(geom);
         sourcesPk.add(pk);
+        sourcesPkIndex.putIfAbsent(pk, sourcesPk.size() - 1);
     }
 
     /**
@@ -178,6 +181,7 @@ public class Scene {
         sourceGeometries.clear();
         sourceOrientation.clear();
         sourcesPk.clear();
+        sourcesPkIndex.clear();
         sourcesIndex = new QueryRTree();
     }
 }


### PR DESCRIPTION
In traffic flow mode without a SLOPE column, processTrafficFlow calls sourcesPk.indexOf() for every row of the emission table to find the source geometry and compute its slope. Each call scans the source list, so loading a cell costs O(sources^2 x periods) and becomes the main cost of the loading phase with many sources in range.

Keep a map from source primary key to list index in Scene, filled in addSource and cleared in clearSources, and read it instead of indexOf. putIfAbsent keeps the same result as indexOf when a key is present several times (first occurrence).

Benchmark (point sources with a traffic emission table, 10 periods, 1 receiver, 1 thread):
- 20000 sources:  3.8 s -> 2.9 s
- 50000 sources: 13.2 s -> 6.0 s Output tables are identical. The noisemodelling-pathfinder test suite, SceneWithEmissionTest and NoiseMapByReceiverMakerTest pass.