### PR TITLE
Set the octave band frequency in the dynamic emission scripts

### DIFF
--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Flow_2_Noisy_Vehicles.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Flow_2_Noisy_Vehicles.groovy
@@ -549,6 +549,7 @@ class Vehicle {
             RoadVehicleCnossosvarParameters rsParametersDynamic = new RoadVehicleCnossosvarParameters(
                     speed * 3.6, 0, vehicle_type, 0,  true, 1, id      )
             rsParametersDynamic.setRoadSurface("DEF")
+            rsParametersDynamic.setFrequency(freqs[i])
             // remove lw_correction
             result[i] = RoadVehicleCnossosvar.evaluate(rsParametersDynamic) + lw_correction;
         }
@@ -750,6 +751,7 @@ class IndividualVehicleEmissionProcessData {
                 RoadVehicleCnossosvarParameters rsParameters = new RoadVehicleCnossosvarParameters(speed, acc, veh_type, acc_type, Stud, LwStd, VehId)
                 rsParameters.setRoadSurface(RoadSurface)
                 rsParameters.setSlopePercentage(0)
+                rsParameters.setFrequency(FreqParam)
 
                 res_LV[kk] = RoadVehicleCnossosvar.evaluate(rsParameters)
                 kk++
@@ -776,6 +778,7 @@ class IndividualVehicleEmissionProcessData {
                 RoadVehicleCnossosvarParameters rsParameters = new RoadVehicleCnossosvarParameters(speed, acc, veh_type, acc_type, Stud, LwStd, VehId)
                 rsParameters.setSlopePercentage(0)
                 rsParameters.setRoadSurface(RoadSurface)
+                rsParameters.setFrequency(FreqParam)
                 res_HV[kk] = RoadVehicleCnossosvar.evaluate(rsParameters)
                 kk++
             }

--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Ind_Vehicles_2_Noisy_Vehicles.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Ind_Vehicles_2_Noisy_Vehicles.groovy
@@ -309,6 +309,7 @@ class VehicleEmissionProcessData {
             RoadVehicleCnossosvarParameters rsParameters = new RoadVehicleCnossosvarParameters(speed, acc, veh_type, acc_type, Stud, LwStd, VehId)
             rsParameters.setRoadSurface(RoadSurface)
             rsParameters.setSlopePercentage(0)
+            rsParameters.setFrequency(f)
             res_LV[kk] = RoadVehicleCnossosvar.evaluate(rsParameters)
             kk++
         }


### PR DESCRIPTION
The per-band emission loops of Ind_Vehicles_2_Noisy_Vehicles and Flow_2_Noisy_Vehicles never called setFrequency on the RoadVehicleCnossosvarParameters, so RoadVehicleCnossosvar.evaluate was always reading the 63 Hz coefficients (an unset frequency falls back to band index 0 in RoadCnossos.getCoeff). Every vehicle emission spectrum was flat: for a light vehicle at 50 km/h the scripts produced 99.1 dB in all 8 bands where the correct spectrum goes down to 77.4 dB at 8000 Hz. High frequencies were overestimated by up to 22 dB in every dynamic noise map.

Set the frequency of the band in the four loops. In Flow_2 getCarsLevel the FreqParam local already existed but was never used. TestDynamic passes.