### PR TITLE
Move frequency independent work out of the attenuation loop, share profile geometry between paths

### DIFF
--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/cnossos/AttenuationCnossos.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/cnossos/AttenuationCnossos.java
@@ -201,9 +201,14 @@ public class AttenuationCnossos {
      */
     public static double[] aDiv(CnossosPath pathParameters, AttenuationParameters data) {
         double[] aDiv = new double[data.getFrequencies().size()];
-        long difVPointCount = pathParameters.getPointList().stream().
-                filter(pointPath -> pointPath.type.equals(DIFV)).count();
-        Arrays.fill(aDiv, getADiv(difVPointCount == 0 ? pathParameters.getSRSegment().d : pathParameters.getSRSegment().dc));
+        boolean hasDifVPoint = false;
+        for (PointPath pointPath : pathParameters.getPointList()) {
+            if (pointPath.type.equals(DIFV)) {
+                hasDifVPoint = true;
+                break;
+            }
+        }
+        Arrays.fill(aDiv, getADiv(!hasDifVPoint ? pathParameters.getSRSegment().d : pathParameters.getSRSegment().dc));
         return aDiv;
     }
 
@@ -244,28 +249,50 @@ public class AttenuationCnossos {
     public static double[] aBoundary(CnossosPath path, AttenuationParameters data) {
         double[] aGround = new double[data.getFrequencies().size()];
         double[] aDif = new double[data.getFrequencies().size()];
-        List<PointPath> diffPts = path.getPointList().stream().
-                filter(pointPath -> pointPath.type.equals(DIFH_RCRIT) || pointPath.type.equals(DIFH)
-                        || pointPath.type.equals(DIFV)).collect(Collectors.toList());
+        // Count the diffraction points and find the first one once, before the frequency
+        // loop, as they do not depend on the frequency. Only the presence of the DIFH_RCRIT
+        // point depends on the Rayleigh criterion, so keep the first point with and without it.
+        long difHCount = 0;
+        long difVCount = 0;
+        PointPath firstDif = null;
+        PointPath firstDifWithRcrit = null;
+        for (PointPath pointPath : path.getPointList()) {
+            boolean difH = pointPath.type.equals(DIFH);
+            boolean difV = pointPath.type.equals(DIFV);
+            if (difH) {
+                difHCount++;
+            }
+            if (difV) {
+                difVCount++;
+            }
+            if ((difH || difV) && firstDif == null) {
+                firstDif = pointPath;
+            }
+            if ((difH || difV || pointPath.type.equals(DIFH_RCRIT)) && firstDifWithRcrit == null) {
+                firstDifWithRcrit = pointPath;
+            }
+        }
+        boolean recordGround = path.groundAttenuation != null && path.groundAttenuation.aGround != null;
         path.aBoundary.init(data.getFrequencies().size());
         // Without diff
         for(int i=0; i<data.getFrequencies().size(); i++) {
-            int finalI = i;
-            boolean isValidRCriterion = isValidRcrit(path, data.getFrequencies().get(finalI));
-            PointPath first = diffPts.stream()
-                    .filter(pp -> pp.type.equals(PointPath.POINT_TYPE.DIFH) || pp.type.equals(DIFV) ||
-                            (pp.type.equals(DIFH_RCRIT) && isValidRCriterion ))
-                    .findFirst()
-                    .orElse(null);
-            aGround[i] = path.isFavourable() ?
-                    aGroundF(path, path.getSRSegment(), data, i) :
-                    aGroundH(path, path.getSRSegment(), data, i);
-            if(path.groundAttenuation != null && path.groundAttenuation.aGround != null) {
-                path.groundAttenuation.aGround[i] = aGround[i];
+            boolean isValidRCriterion = isValidRcrit(path, data.getFrequencies().get(i));
+            PointPath first = isValidRCriterion ? firstDifWithRcrit : firstDif;
+            // When the first diffraction is horizontal and the Rayleigh criterion is valid,
+            // the ground attenuation is replaced by zero below, so do not compute it for
+            // nothing (unless it is kept for the attenuation matrix export)
+            boolean groundReplacedByDif = first != null && !first.type.equals(DIFV) && isValidRCriterion;
+            if (!groundReplacedByDif || recordGround || path.keepAbsorption) {
+                aGround[i] = path.isFavourable() ?
+                        aGroundF(path, path.getSRSegment(), data, i) :
+                        aGroundH(path, path.getSRSegment(), data, i);
+                if (recordGround) {
+                    path.groundAttenuation.aGround[i] = aGround[i];
+                }
             }
             if (first != null) {
-                aDif[i] = aDif(path, data, i, first.type);
-                if(!first.type.equals(DIFV) && isValidRCriterion) {
+                aDif[i] = aDif(path, data, i, first.type, difHCount, difVCount);
+                if (groundReplacedByDif) {
                     aGround[i] = 0.;
                 }
             } else {
@@ -367,14 +394,13 @@ public class AttenuationCnossos {
      * @param type Type of diffraction
      * @return the value of ADiv
      */
-    private static double aDif(CnossosPath proPathParameters, AttenuationParameters data, int frequencyIndex, PointPath.POINT_TYPE type) {
+    private static double aDif(CnossosPath proPathParameters, AttenuationParameters data, int frequencyIndex,
+                               PointPath.POINT_TYPE type, long difHCount, long difVCount) {
         SegmentPath first = proPathParameters.getSegmentList().get(0);
         SegmentPath last = proPathParameters.getSegmentList().get(proPathParameters.getSegmentList().size()-1);
 
         double ch = 1.;
         double lambda = 340.0 / data.getFrequencies().get(frequencyIndex);
-        long difHCount = proPathParameters.getPointList().stream().filter(pointPath -> pointPath.type.equals(DIFH)).count();
-        long difVCount = proPathParameters.getPointList().stream().filter(pointPath -> pointPath.type.equals(DIFV)).count();
         double cSecond = (type.equals(PointPath.POINT_TYPE.DIFH) && difHCount <= 1) || (type.equals(DIFV) && difVCount <= 1) || proPathParameters.e <= 0.3 ? 1. :
                 (1+pow(5*lambda/ proPathParameters.e, 2))/(1./3+pow(5*lambda/ proPathParameters.e, 2));
 
@@ -590,11 +616,6 @@ public class AttenuationCnossos {
         if (data == null) {
             return new double[0];
         }
-        // cache frequencies
-        double[] frequencies = new double[0];
-        if(scene != null) {
-            frequencies =  scene.profileBuilder.frequencyArray.stream().mapToDouble(value -> value).toArray();
-        }
         // Compute receiver/source attenuation
         if(exportAttenuationMatrix) {
             proPathParameters.keepAbsorption = true;
@@ -623,7 +644,13 @@ public class AttenuationCnossos {
         // todo get hRail from input data
         double hRail = 0.5;
         Coordinate src = ptList.get(0).coordinate;
-        PointPath pDif = ptList.stream().filter(p -> p.type.equals(PointPath.POINT_TYPE.DIFH)).findFirst().orElse(null);
+        PointPath pDif = null;
+        for (PointPath p : ptList) {
+            if (p.type.equals(PointPath.POINT_TYPE.DIFH)) {
+                pDif = p;
+                break;
+            }
+        }
 
         if (pDif != null && !pDif.alphaWall.isEmpty()) {
             if (pDif.bodyBarrier){
@@ -784,6 +811,7 @@ public class AttenuationCnossos {
         double sourceLi = proPathParameters.getCutProfile().getSource().li;
 
         if(scene != null && !scene.isOmnidirectional(sourceId)) {
+            double[] frequencies = scene.profileBuilder.frequencyArray.stream().mapToDouble(value -> value).toArray();
             Orientation directivityToPick = proPathParameters.raySourceReceiverDirectivity;
             double[] attSource = scene.getSourceAttenuation( sourceId,
                     frequencies, Math.toRadians(directivityToPick.yaw),

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/cnossos/CnossosPathBuilder.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/cnossos/CnossosPathBuilder.java
@@ -197,9 +197,23 @@ public class CnossosPathBuilder {
         List<CnossosPath> cnossosPaths = new ArrayList<>();
         if(cutProfile.profileType == CutProfile.PROFILE_TYPE.DIRECT ||
                 cutProfile.profileType == CutProfile.PROFILE_TYPE.REFLECTION) {
-            CnossosPath cnossosPath = computeCnossosPathFromCutProfile(cutProfile, bodyBarrier, exactFrequencyArray, gS, false);
+            // The 2D projection of the profile, the ground points and the mean ground plane are
+            // the same for the homogeneous and the favourable path, so compute them only once here
+            List<Coordinate> pts2D = cutProfile.computePts2D();
+            List<Integer> cut2DGroundIndex = new ArrayList<>(cutProfile.cutPoints.size());
+            Coordinate[] pts2DGround = cutProfile.computePts2DGround(cut2DGroundIndex).toArray(new Coordinate[0]);
+            double[] meanPlane = JTSUtility.getMeanPlaneCoefficients(pts2DGround);
+            CnossosPath cnossosPath = computeCnossosPathFromCutProfile(cutProfile, bodyBarrier, exactFrequencyArray,
+                    gS, false, pts2D, pts2DGround, cut2DGroundIndex, meanPlane);
             if(cnossosPath != null) cnossosPaths.add(cnossosPath);
-            cnossosPath = computeCnossosPathFromCutProfile(cutProfile, bodyBarrier, exactFrequencyArray, gS, true);
+            // Give a copy of the 2D points to the favourable path, because building a path can
+            // move the height of its reflection points (each path must have its own points)
+            List<Coordinate> pts2DCopy = new ArrayList<>(pts2D.size());
+            for (Coordinate coordinate : pts2D) {
+                pts2DCopy.add(new Coordinate(coordinate));
+            }
+            cnossosPath = computeCnossosPathFromCutProfile(cutProfile, bodyBarrier, exactFrequencyArray,
+                    gS, true, pts2DCopy, pts2DGround, cut2DGroundIndex, meanPlane);
             if(cnossosPath != null) cnossosPaths.add(cnossosPath);
         } else if (cutProfile.profileType == CutProfile.PROFILE_TYPE.LEFT ||
                 cutProfile.profileType == CutProfile.PROFILE_TYPE.RIGHT) {
@@ -220,6 +234,28 @@ public class CnossosPathBuilder {
      * @return The cnossos path or null
      */
     public static CnossosPath computeCnossosPathFromCutProfile(CutProfile cutProfile , boolean bodyBarrier, List<Double> exactFrequencyArray, double gS, boolean favourable) {
+        List<Coordinate> pts2D = cutProfile.computePts2D();
+        List<Integer> cut2DGroundIndex = new ArrayList<>(cutProfile.cutPoints.size());
+        Coordinate[] pts2DGround = cutProfile.computePts2DGround(cut2DGroundIndex).toArray(new Coordinate[0]);
+        double[] meanPlane = JTSUtility.getMeanPlaneCoefficients(pts2DGround);
+        return computeCnossosPathFromCutProfile(cutProfile, bodyBarrier, exactFrequencyArray, gS, favourable,
+                pts2D, pts2DGround, cut2DGroundIndex, meanPlane);
+    }
+
+    /**
+     * Same as {@link #computeCnossosPathFromCutProfile(CutProfile, boolean, List, double, boolean)} but with the
+     * profile geometry already computed, so it is not computed twice when the same profile gives
+     * the homogeneous and the favourable path.
+     * @param pts2D 2D projection of the cut points, may be updated by this method (reflection points)
+     * @param pts2DGround 2D projection of the ground, read only
+     * @param cut2DGroundIndex Ground point index for each cut point, read only
+     * @param meanPlane Mean ground plane coefficients of the whole profile, read only
+     */
+    private static CnossosPath computeCnossosPathFromCutProfile(CutProfile cutProfile , boolean bodyBarrier,
+                                                                List<Double> exactFrequencyArray, double gS,
+                                                                boolean favourable, List<Coordinate> pts2D,
+                                                                Coordinate[] pts2DGround,
+                                                                List<Integer> cut2DGroundIndex, double[] meanPlane) {
         if(favourable &&
                 (cutProfile.profileType == CutProfile.PROFILE_TYPE.LEFT ||
                         cutProfile.profileType == CutProfile.PROFILE_TYPE.RIGHT)
@@ -232,14 +268,10 @@ public class CnossosPathBuilder {
         // Use original cutPoints for all calculations (no transformation)
         final List<CutPoint> cutProfilePoints = cutProfile.cutPoints;
 
-        List<Coordinate> pts2D = cutProfile.computePts2D();
         if(pts2D.size() != cutProfilePoints.size()) {
             throw new IllegalArgumentException("The two arrays size should be the same");
         }
 
-        List<Integer> cut2DGroundIndex = new ArrayList<>(cutProfilePoints.size());
-        Coordinate[] pts2DGround = cutProfile.computePts2DGround(cut2DGroundIndex).toArray(new Coordinate[0]);
-        double[] meanPlane = JTSUtility.getMeanPlaneCoefficients(pts2DGround);
         Coordinate firstPts2D = pts2D.get(0);
         Coordinate lastPts2D = pts2D.get(pts2D.size()-1);
         SegmentPath srPath = computeSegment(firstPts2D, lastPts2D, meanPlane, cutProfile.getGPath(), cutProfile.getSource().groundCoefficient);


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Two commits that reduce redundant work when converting a cut profile into its CNOSSOS paths and computing their attenuation. <strong>Results are identical</strong>: the CNOSSOS reference tests pass unchanged, and benchmark output checksums are byte for byte the same.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Commit 1 — shared profile geometry</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">For a DIRECT/REFLECTION profile, the homogeneous and favourable paths were built by two independent calls that each recomputed the same 2D projection, ground points and mean ground plane. They are now computed once and passed to both calls (public signatures unchanged; the favourable call gets a copy of the 2D points because path building may move reflection point heights). Honest measurement: only ~6% of the conversion step — kept mostly as the base for commit 2.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Commit 2 — frequency loop hoisting (the substantial one)</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">computeCnossosAttenuation</code> runs per path (× per period with dedicated weather). Inside its per-band loop: <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">aBoundary</code> re-found the first diffraction point with a stream per band, <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">aDif</code> re-counted DIFH/DIFV points with two streams per band, and the ground attenuation was computed for every band then replaced by zero whenever a valid horizontal diffraction exists (the common case in cities). All of this is now done once before the loop, or skipped when unused (debug/export behaviour preserved).</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Measurements</h2>
Attenuation of one path | Before | After
-- | -- | --
With diffraction, 8 octave bands | 5.0 µs | 2.7 µs
With diffraction, 24 third-octave bands | 13.0 µs | 7.2 µs
Free field, 8 / 24 bands | 2.1 / 4.7 µs | 1.5 / 3.5 µs

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Full urban computation (625 buildings, landcover, 160 000 source-receiver pairs): 6–18% faster across repeated runs. Open flat scenes: no visible change (attenuation is a small share there). Gains multiply with the number of periods when per-period weather settings are used.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">noisemodelling-pathfinder</code> (91), <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">noisemodelling-propagation</code> (51, incl. CNOSSOS reference values) and jdbc attenuation tests (18) pass.</p><br class="Apple-interchange-newline"><!--EndFragment-->
</body>
</html>