### PR TITLE
Index the walls in the receiver image search and skip it without sources

### DIFF
--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
@@ -180,18 +180,6 @@ public class PathFinder {
         MirrorReceiversCompute receiverMirrorIndex = null;
 
         long reflectionPreprocessTime = 0;
-        if(data.reflexionOrder > 0) {
-            Envelope receiverPropagationEnvelope = new Envelope(receiverPointInfo.getCoordinates());
-            receiverPropagationEnvelope.expandBy(data.maxSrcDist);
-            List<Wall> buildWalls = data.profileBuilder.getWallsIn(receiverPropagationEnvelope);
-            receiverMirrorIndex = new MirrorReceiversCompute(buildWalls, receiverPointInfo.position, data.reflexionOrder,
-                    data.maxSrcDist, data.maxRefDist);
-            if(profilerThread != null) {
-                reflectionPreprocessTime = TimeUnit.MILLISECONDS.convert(System.nanoTime() - start,
-                        TimeUnit.NANOSECONDS);
-            }
-        }
-
 
         long startSourceCollect = 0;
         if(profilerThread != null) {
@@ -253,6 +241,24 @@ public class PathFinder {
         long sourceCollectTime = 0;
         if(profilerThread != null) {
             sourceCollectTime = TimeUnit.MILLISECONDS.convert(System.nanoTime() - startSourceCollect, TimeUnit.NANOSECONDS);
+        }
+
+        // Build the receiver images index after the source collection, so the (expensive)
+        // construction is skipped for the receivers without any source in range
+        if(data.reflexionOrder > 0 && !sourceList.isEmpty()) {
+            long startReflectionPreprocess = 0;
+            if(profilerThread != null) {
+                startReflectionPreprocess = System.nanoTime();
+            }
+            Envelope receiverPropagationEnvelope = new Envelope(receiverPointInfo.getCoordinates());
+            receiverPropagationEnvelope.expandBy(data.maxSrcDist);
+            List<Wall> buildWalls = data.profileBuilder.getWallsIn(receiverPropagationEnvelope);
+            receiverMirrorIndex = new MirrorReceiversCompute(buildWalls, receiverPointInfo.position, data.reflexionOrder,
+                    data.maxSrcDist, data.maxRefDist);
+            if(profilerThread != null) {
+                reflectionPreprocessTime = TimeUnit.MILLISECONDS.convert(System.nanoTime() - startReflectionPreprocess,
+                        TimeUnit.NANOSECONDS);
+            }
         }
 
         AtomicInteger processedSources = new AtomicInteger(0);

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/path/MirrorReceiversCompute.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/path/MirrorReceiversCompute.java
@@ -16,7 +16,10 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineSegment;
+import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.locationtech.jts.index.ItemVisitor;
 import org.locationtech.jts.index.strtree.STRtree;
 import org.locationtech.jts.io.WKTWriter;
@@ -102,6 +105,20 @@ public class MirrorReceiversCompute {
         this.maximumDistanceFromWall = maximumDistanceFromWall;
         this.maximumPropagationDistance = maximumPropagationDistance;
         mirrorReceiverTree = new STRtree();
+        // Create the geometry of each wall once, and index them, instead of creating a new
+        // geometry for every parent image x wall combination in the loop below
+        List<LineString> wallGeometries = new ArrayList<>(buildWalls.size());
+        for (Wall wall : buildWalls) {
+            wallGeometries.add(wall.getLineSegment().toGeometry(gf));
+        }
+        STRtree wallsTree = null;
+        if (reflectionOrder > 1) {
+            wallsTree = new STRtree();
+            for (int idWall = 0; idWall < buildWalls.size(); idWall++) {
+                wallsTree.insert(wallGeometries.get(idWall).getEnvelopeInternal(), idWall);
+            }
+            wallsTree.build();
+        }
         ArrayList<MirrorReceiver> parentsToProcess = new ArrayList<>();
         for(int currentDepth = 0; currentDepth < reflectionOrder; currentDepth++) {
             if(currentDepth == 0) {
@@ -109,11 +126,22 @@ public class MirrorReceiversCompute {
             }
             ArrayList<MirrorReceiver> nextParentsToProcess = new ArrayList<>();
             for(MirrorReceiver parent : parentsToProcess) {
-                for (Wall wall : buildWalls) {
+                // For the first depth every wall can create an image. For the next depths only
+                // the walls under the visibility cone of the parent image can, so ask the wall
+                // index instead of testing every wall
+                List<?> wallCandidates = null;
+                PreparedGeometry parentCone = null;
+                if (parent != null) {
+                    wallCandidates = wallsTree.query(parent.getImageReceiverVisibilityCone().getEnvelopeInternal());
+                    parentCone = PreparedGeometryFactory.prepare(parent.getImageReceiverVisibilityCone());
+                }
+                int candidateCount = parent == null ? buildWalls.size() : wallCandidates.size();
+                for (int idCandidate = 0; idCandidate < candidateCount; idCandidate++) {
+                    int wallIndex = parent == null ? idCandidate : (Integer) wallCandidates.get(idCandidate);
+                    Wall wall = buildWalls.get(wallIndex);
                     if(parent != null) {
                         // check if the wall is visible from the previous image receiver
-                        if(!parent.getImageReceiverVisibilityCone().intersects(
-                                wall.getLineSegment().toGeometry(new GeometryFactory()))) {
+                        if(!parentCone.intersects(wallGeometries.get(wallIndex))) {
                             continue; // this wall is out of the bound of the receiver visibility
                         }
                     }


### PR DESCRIPTION
The receiver image index (MirrorReceiversCompute) is built once per receiver when reflections are enabled. Two problems:

- For reflection order 2 and more, every image of the previous depth tested every wall of the area with a JTS intersects against a wall geometry created for each image x wall pair. With W walls this is O(W^2) polygon tests per receiver. The wall geometries are now created once, indexed in a STRtree, and each image only tests the walls under the envelope of its visibility cone, with a prepared geometry for the cone. Same set of images as before, found faster.
- The index was built before looking for the sources, so receivers with no source in range paid the full construction for nothing. It is now built after the source collection, only when needed.

The result tables are identical (same checksums). Benchmark, urban scene with 625 buildings, one thread:
- reflection order 2, sources everywhere: 5.2-5.7 s -> 3.3-3.4 s
- reflection order 2, sources in a corner: 3.8 s -> 1.5 s
- reflection order 1: unchanged (the wall loop only runs at order 2) The pathfinder test suite (including TestWallReflection), the propagation CNOSSOS reference tests and the jdbc attenuation tests pass.

Note: while benchmarking we hit a pre-existing crash in PathFinder.computeReflexion (IndexOutOfBoundsException) when a source lies exactly on the line of a wall. It is not related to this change and can be reproduced on main; it should be reported separately.