### PR TITLE
Fix crash in computeReflexion when a source is exactly on a wall

### DIFF
--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
@@ -675,6 +675,10 @@ public class PathFinder {
         for (MirrorReceiver receiverReflection : mirrorResults) {
             Wall seg = receiverReflection.getWall();
             List<MirrorReceiver> rayPath = new ArrayList<>();
+            // Set to true only when the full chain of reflections has a reflection point,
+            // the loop below stops early on degenerate geometry (for example when the source
+            // lies exactly on the wall, the reflection point is the source itself)
+            boolean completeReflectionChain = false;
             MirrorReceiver receiverReflectionCursor = receiverReflection;
             // Test whether intersection point is on the wall
             // segment or not
@@ -713,6 +717,7 @@ public class PathFinder {
                 rayPath.add(reflResult);
                 if (receiverReflectionCursor
                         .getParentMirror() == null) { // Direct to the receiver
+                    completeReflectionChain = true;
                     break; // That was the last reflection
                 } else {
                     // There is another reflection
@@ -728,6 +733,10 @@ public class PathFinder {
                             destinationPt
                     );
                 }
+            }
+            if (!completeReflectionChain) {
+                // The reflection chain could not be completed, ignore this image receiver
+                continue;
             }
             // Compute direct path between source and first reflection point, add profile to the data
             CutProfile segmentCutProfile = data.profileBuilder.getProfile(src.position, rayPath.get(0).getReflectionPosition(),

--- a/noisemodelling-pathfinder/src/test/java/org/noise_planet/noisemodelling/pathfinder/TestWallReflection.java
+++ b/noisemodelling-pathfinder/src/test/java/org/noise_planet/noisemodelling/pathfinder/TestWallReflection.java
@@ -88,6 +88,48 @@ public class TestWallReflection {
     }
 
     @Test
+    public void testSourceOnWallSegment() {
+        GeometryFactory factory = new GeometryFactory();
+        ProfileBuilder profileBuilder = new ProfileBuilder();
+        profileBuilder.addBuilding(new Coordinate[]{
+                new Coordinate(0, 0, 10),
+                new Coordinate(10, 0, 10),
+                new Coordinate(10, 10, 10),
+                new Coordinate(0, 10, 10)});
+        profileBuilder.finishFeeding();
+        Scene inputData = new Scene(profileBuilder);
+        inputData.addReceiver(new Coordinate(5, -20, 4));
+        // The source is exactly on a wall of the building, so the reflection point on this
+        // wall is the source itself and no reflection path can be built from it
+        inputData.addSource(factory.createPoint(new Coordinate(5, 0, 1)));
+        inputData.setComputeHorizontalDiffraction(false);
+        inputData.setComputeVerticalDiffraction(false);
+        inputData.maxRefDist = 80;
+        inputData.maxSrcDist = 180;
+        inputData.setReflexionOrder(1);
+        PathFinder computeRays = new PathFinder(inputData);
+        computeRays.setThreadCount(1);
+
+        Coordinate receiver = inputData.receivers.get(0);
+        Envelope receiverPropagationEnvelope = new Envelope(receiver);
+        receiverPropagationEnvelope.expandBy(inputData.maxSrcDist);
+        List<Wall> buildWalls = inputData.profileBuilder.getWallsIn(receiverPropagationEnvelope);
+        MirrorReceiversCompute receiverMirrorIndex = new MirrorReceiversCompute(buildWalls, receiver,
+                inputData.reflexionOrder, inputData.maxSrcDist, inputData.maxRefDist);
+
+        DefaultCutPlaneVisitor defaultCutPlaneVisitor = new DefaultCutPlaneVisitor(true, inputData);
+
+        // Must not throw even if the reflection point is the source position
+        computeRays.computeReflexion(new PathFinder.ReceiverPointInfo(1, 1, receiver),
+                new PathFinder.SourcePointInfo(1, 1, inputData.sourceGeometries.get(0).getCoordinate(), 1.0,
+                        new Orientation()), receiverMirrorIndex, defaultCutPlaneVisitor,
+                CutPlaneVisitor.PathSearchStrategy.CONTINUE);
+
+        // The degenerate reflection is ignored, no reflection path is expected
+        assertTrue(defaultCutPlaneVisitor.cutProfiles.isEmpty());
+    }
+
+    @Test
     public void testNReflexion() throws ParseException, IOException, SQLException {
         GeometryFactory factory = new GeometryFactory();
 


### PR DESCRIPTION
**The bug**
When a source point lies exactly on the line of a reflecting wall and reflections are enabled, the reflection point computed in PathFinder.computeReflexion is the source position itself. The reflection chain loop then stops before adding any point, and rayPath.get(0) throws IndexOutOfBoundsException, aborting the whole computation. This can happen with real data as soon as a source point touches a building wall (for example road source points snapped to facades).

**Origin**
This is a regression from the October 2024 refactoring (8a8d3cfd and following, which build the full CutProfile from receiver to source). Before it, a validReflection flag protected this code: an incomplete reflection chain skipped the image receiver. The rewrite of the loop lost that protection.

**The fix**
Restore the guard: the image receiver is ignored unless the loop built the complete chain of reflection points (flag named completeReflectionChain, as the refactored code already uses validReflection for another check further down). Behaviour is the same as before October 2024: degenerate reflections are silently ignored.

A test reproducing the crash is included (testSourceOnWallSegment, source on a building wall): it fails with the exact IndexOutOfBoundsException without the fix and passes with it. The pathfinder suite (92 tests) and the propagation CNOSSOS reference tests pass.