### PR TITLE
Share the walls and plane cuts between the four side hull searches

### DIFF
--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
@@ -357,9 +357,12 @@ public class PathFinder {
         // between source and receiver is blocked and does not penetrate the terrain profile.
         // In addition, the source must not be a mirror source due to reflection"
         if (horizontalDiffraction && !cutProfile.isFreeField()) {
+            // The four side hull searches (left/right x straight/curved) share the same walls
+            // and the same plane cuts, the visitor caches them
+            BuildingIntersectionPathVisitor sideHullVisitor = createSideHullVisitor(src.position, rcv.position);
             for(boolean curved : new boolean[]{false, true}) {
                 for(PathFinder.ComputationSide side : PathFinder.ComputationSide.values()) {
-                    CutProfile cutProfileSide = computeVEdgeDiffraction(rcv, src, data, side, curved);
+                    CutProfile cutProfileSide = computeVEdgeDiffraction(rcv, src, data, side, curved, sideHullVisitor);
                     if (cutProfileSide != null) {
                         strategy = dataOut.onNewCutPlane(cutProfileSide);
                         if(strategy.equals(CutPlaneVisitor.PathSearchStrategy.SKIP_SOURCE) ||
@@ -384,9 +387,20 @@ public class PathFinder {
      */
     public CutProfile computeVEdgeDiffraction(ReceiverPointInfo rcv, SourcePointInfo src,
                                                Scene data, ComputationSide side, boolean curved) {
+        return computeVEdgeDiffraction(rcv, src, data, side, curved,
+                createSideHullVisitor(src.position, rcv.position));
+    }
+
+    /**
+     * Same as {@link #computeVEdgeDiffraction(ReceiverPointInfo, SourcePointInfo, Scene, ComputationSide, boolean)}
+     * with a visitor that can be shared between the four searches of the same source-receiver couple.
+     */
+    public CutProfile computeVEdgeDiffraction(ReceiverPointInfo rcv, SourcePointInfo src,
+                                              Scene data, ComputationSide side, boolean curved,
+                                              BuildingIntersectionPathVisitor sideHullVisitor) {
 
         List<Coordinate> coordinates = computeSideHull(side == LEFT, new Coordinate(src.position),
-                new Coordinate(rcv.position), curved);
+                new Coordinate(rcv.position), curved, sideHullVisitor);
 
         List<CutPoint> cutPoints = new ArrayList<>();
 
@@ -474,12 +488,31 @@ public class PathFinder {
      * @return Intersection points between the plane formed by p1 and p2 and the buildings walls
      */
     public List<Coordinate> computeSideHull(boolean left, Coordinate p1, Coordinate p2, boolean curved) {
+        return computeSideHull(left, p1, p2, curved, createSideHullVisitor(p1, p2));
+    }
+
+    /**
+     * Create the visitor used to search the side hull points between two positions.
+     * One instance can be shared by the four side hull searches of the same source-receiver
+     * couple (left/right x straight/curved), so the walls lookup and the plane cuts are done
+     * only once for the four searched paths.
+     */
+    public BuildingIntersectionPathVisitor createSideHullVisitor(Coordinate p1, Coordinate p2) {
+        Coordinate sourcePosition = new Coordinate(p1);
+        Coordinate receiverPosition = new Coordinate(p2);
+        return new BuildingIntersectionPathVisitor(sourcePosition, receiverPosition, true,
+                data.profileBuilder, new ArrayList<>(), computeZeroRadPlane(sourcePosition, receiverPosition));
+    }
+
+    /**
+     * Same as {@link #computeSideHull(boolean, Coordinate, Coordinate, boolean)} with a visitor
+     * that can be shared between the side hull searches of the same source-receiver couple.
+     */
+    public List<Coordinate> computeSideHull(boolean left, Coordinate p1, Coordinate p2, boolean curved,
+                                            BuildingIntersectionPathVisitor buildingIntersectionPathVisitor) {
         if (p1.equals(p2)) {
             return new ArrayList<>();
         }
-
-        // Intersection test cache
-        Set<LineSegment> freeFieldSegments = new HashSet<>();
 
         List<Coordinate> input = new ArrayList<>();
 
@@ -490,16 +523,17 @@ public class PathFinder {
         input.add(p1);
         input.add(p2);
 
-        Plane cutPlane = computeZeroRadPlane(p1, p2);
-
-        BuildingIntersectionPathVisitor buildingIntersectionPathVisitor = new BuildingIntersectionPathVisitor(p1, p2, left,
-                data.profileBuilder, input, cutPlane);
-
         // The roof vertices of buildings will be moved downward if the curved coordinate system is used
         // This will return the altered cut plane intersection coordinates, so the coordinate must be restored before returning it
-        buildingIntersectionPathVisitor.setCurved(curved);
+        buildingIntersectionPathVisitor.reset(left, curved, input);
 
-        data.profileBuilder.getWallsOnPath(p1, p2, buildingIntersectionPathVisitor);
+        if (buildingIntersectionPathVisitor.isCandidatesCollected()) {
+            // Reuse the walls found by the first search of this source-receiver couple
+            buildingIntersectionPathVisitor.replayCandidates();
+        } else {
+            data.profileBuilder.getWallsOnPath(p1, p2, buildingIntersectionPathVisitor);
+            buildingIntersectionPathVisitor.setCandidatesCollected(true);
+        }
 
         int k;
 

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/BuildingIntersectionPathVisitor.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/BuildingIntersectionPathVisitor.java
@@ -39,6 +39,13 @@ public final class BuildingIntersectionPathVisitor implements ItemVisitor {
     LineSegment intersectionLine = new LineSegment();
     private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
     boolean curved = false;
+    // Caches shared between the four side hull searches of the same source-receiver couple
+    // (left/right x straight/curved): the candidate walls and the plane cuts do not depend
+    // on the side, and the curved rejection does not depend on the side either
+    List<Integer> acceptedCandidates = new ArrayList<>();
+    boolean candidatesCollected = false;
+    Map<Integer, List<Coordinate>> planeCutCache = new HashMap<>();
+    Map<Integer, Boolean> curvedRejectCache = new HashMap<>();
 
     public BuildingIntersectionPathVisitor(Coordinate p1, Coordinate p2, boolean left, ProfileBuilder profileBuilder,
                                            List<Coordinate> input, Plane cutPlane) {
@@ -81,6 +88,44 @@ public final class BuildingIntersectionPathVisitor implements ItemVisitor {
         itemProcessed.clear();
     }
 
+    /**
+     * Prepare the visitor for a new side hull search of the same source-receiver couple.
+     * The candidate walls and the plane cut caches are kept.
+     * @param left Side to search
+     * @param curved True to search with the curved coordinate system
+     * @param input Where the hull points are pushed
+     */
+    public void reset(boolean left, boolean curved, List<Coordinate> input) {
+        this.left = left;
+        this.curved = curved;
+        this.input = input;
+        itemProcessed.clear();
+        pushedBuildingsWideAnglePoints.clear();
+        pushedWallsPoints.clear();
+    }
+
+    /**
+     * @return True when the candidate walls of the first search can be processed again with
+     * {@link #replayCandidates()} instead of asking the spatial index again
+     */
+    public boolean isCandidatesCollected() {
+        return candidatesCollected;
+    }
+
+    public void setCandidatesCollected(boolean candidatesCollected) {
+        this.candidatesCollected = candidatesCollected;
+    }
+
+    /**
+     * Process again the candidate walls accepted by the first search, without asking the
+     * spatial index again
+     */
+    public void replayCandidates() {
+        for (int idCandidate = 0; idCandidate < acceptedCandidates.size(); idCandidate++) {
+            addItem(acceptedCandidates.get(idCandidate));
+        }
+    }
+
 
     /**
      *
@@ -94,6 +139,9 @@ public final class BuildingIntersectionPathVisitor implements ItemVisitor {
             LineObstruction processedObstruction = profileBuilder.getProcessedObstructions().get(id);
             // Check if the wall intersects with the segment (only in 2D so it is useless to have a curved path)
             if(processedObstruction.getLineSegment().distance(intersectionLine) < ProfileBuilder.epsilon) {
+                if (!candidatesCollected) {
+                    acceptedCandidates.add(id);
+                }
                 addItem(id);
             }
         }
@@ -121,19 +169,12 @@ public final class BuildingIntersectionPathVisitor implements ItemVisitor {
                 // weird building, no diffraction point
                 return;
             }
-            if(curved) {
-                // Adjust the altitude of the building roof points to be in the curved coordinate system
-                List<Coordinate> curvedRoofPoints = Arrays.asList(CurvedProfileGenerator.applyTransformation(p1, p2,
-                        roofPoints.toArray(new Coordinate[0]), false));
-                // Create a cut of the building volume with the roof points z moved to the bottom following
-                // the curve coordinate system formulae
-                if(cutRoofPointsWithPlane(cutPlane, curvedRoofPoints).isEmpty()) {
-                    // The building roof is below the curved ray
-                    return;
-                }
+            if(curved && isCurvedRayBelowRoof(id, roofPoints)) {
+                // The building roof is below the curved ray
+                return;
             }
             // Create a cut of the building volume
-            roofPoints = cutRoofPointsWithPlane(cutPlane, roofPoints);
+            roofPoints = cutRoofPointsWithPlaneCached(id, roofPoints);
 
             // remove points that are not on the correct side of the line p1Top2 (use only x,y coordinates)
             roofPoints = filterPointsBySide(p1Top2, left, roofPoints);
@@ -156,19 +197,12 @@ public final class BuildingIntersectionPathVisitor implements ItemVisitor {
             Coordinate extendedP1 = new Coordinate(processedWall.line.p1.x + translationVector.getX(),
                     processedWall.line.p1.y + translationVector.getY(), processedWall.line.p1.z);
             List<Coordinate> roofPoints = Arrays.asList(extendedP0, extendedP1);
-            if(curved) {
-                // Adjust the altitude of the building roof points to be in the curved coordinate system
-                List<Coordinate> curvedRoofPoints = Arrays.asList(CurvedProfileGenerator.applyTransformation(p1, p2,
-                        roofPoints.toArray(new Coordinate[0]), false));
-                // Create a cut of the building volume with the roof points z moved to the bottom following
-                // the curve coordinate system formulae
-                if(cutRoofPointsWithPlane(cutPlane, curvedRoofPoints).isEmpty()) {
-                    // The building roof is below the curved ray
-                    return;
-                }
+            if(curved && isCurvedRayBelowRoof(id, roofPoints)) {
+                // The wall top is below the curved ray
+                return;
             }
             // Create a cut of the building volume
-            roofPoints = cutRoofPointsWithPlane(cutPlane, roofPoints);
+            roofPoints = cutRoofPointsWithPlaneCached(id, roofPoints);
             // remove points that are not on the correct side of the line p1Top2 (use only x,y coordinates)
             roofPoints = filterPointsBySide(p1Top2, left, roofPoints);
             if (!roofPoints.isEmpty()) {
@@ -176,5 +210,36 @@ public final class BuildingIntersectionPathVisitor implements ItemVisitor {
                 input.addAll(roofPoints);
             }
         }
+    }
+
+    /**
+     * Cut of the building volume with the top points z moved to the bottom following the
+     * curved coordinate system formulae, empty when the top is below the curved ray.
+     * The result only depends on the wall, so it is computed once per wall.
+     */
+    private boolean isCurvedRayBelowRoof(int id, List<Coordinate> roofPoints) {
+        Boolean curvedRejected = curvedRejectCache.get(id);
+        if (curvedRejected == null) {
+            // Adjust the altitude of the building roof points to be in the curved coordinate system
+            List<Coordinate> curvedRoofPoints = Arrays.asList(CurvedProfileGenerator.applyTransformation(p1, p2,
+                    roofPoints.toArray(new Coordinate[0]), false));
+            curvedRejected = cutRoofPointsWithPlane(cutPlane, curvedRoofPoints).isEmpty();
+            curvedRejectCache.put(id, curvedRejected);
+        }
+        return curvedRejected;
+    }
+
+    /**
+     * Cut of the building volume with the vertical plane between p1 and p2. The result only
+     * depends on the wall, so it is computed once per wall. Callers must not change the
+     * returned list.
+     */
+    private List<Coordinate> cutRoofPointsWithPlaneCached(int id, List<Coordinate> roofPoints) {
+        List<Coordinate> cutPoints = planeCutCache.get(id);
+        if (cutPoints == null) {
+            cutPoints = cutRoofPointsWithPlane(cutPlane, roofPoints);
+            planeCutCache.put(id, cutPoints);
+        }
+        return cutPoints;
     }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 style="margin-top: 0px; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The problem</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">When the direct sight between a source and a receiver is blocked and horizontal diffraction is enabled (the default), four side hull searches run for the pair: left/right × straight/curved. Each search asked the spatial index for the walls crossing the direct segment and cut every crossed building volume with the vertical plane again — while none of that depends on the side, and the curved rejection of a building does not depend on the side either.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The change</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The four searches of one source–receiver pair now share one visitor:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>the first search records the accepted walls, the next three process the recorded walls without asking the spatial index again;</li><li>the plane cut of each wall is computed once instead of four times, and the curved rejection once instead of twice;</li><li>the cut plane and the prepared segment geometry are created once instead of four times.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Only the side filtering and the convex hull are still computed per search. All existing public signatures are kept as one-shot wrappers. <strong>Results are identical</strong> (same CNOSSOS reference test values including the lateral diffraction cases, same benchmark checksums).</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Measurements</h2>
  | Before | After
-- | -- | --
The four searches of one pair (grid of 100 buildings) | 50 µs | 28 µs
Full urban computation, horizontal diffraction on (625 buildings, landcover, 1 thread) | 8.5–8.6 s | 7.7–8.3 s

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The pathfinder suite (incl. <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">CurvedProfileTest</code>, which uses the single-search entry point), the propagation CNOSSOS reference tests and the jdbc attenuation tests pass.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><!--EndFragment-->
</body>
</html>