### PR TITLE
Process the receivers of a cell in small batches instead of one per thread

### DIFF
--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
@@ -50,6 +50,7 @@ import static org.noise_planet.noisemodelling.pathfinder.PathFinder.ComputationS
 public class PathFinder {
     // distance from wall for reflection points and diffraction points
     private static final double NAVIGATION_POINT_DISTANCE_FROM_WALLS = ProfileBuilder.MILLIMETER;
+    private static final int RECEIVER_BATCHES_PER_THREAD = 16;
     private static final double epsilon = 1e-7;
     private static final double MAX_RATIO_HULL_DIRECT_PATH = 4;
     public static final Logger LOGGER = LoggerFactory.getLogger(PathFinder.class);
@@ -120,7 +121,8 @@ public class PathFinder {
      */
     public void run(CutPlaneVisitorFactory computeRaysOut) {
         ThreadPool threadManager = new ThreadPool(threadCount, threadCount + 1, Long.MAX_VALUE, TimeUnit.SECONDS);
-        int maximumReceiverBatch = (int) ceil(data.receivers.size() / (double) threadCount);
+        int maximumReceiverBatch = (int) max(1,
+                ceil(data.receivers.size() / (double) (threadCount * RECEIVER_BATCHES_PER_THREAD)));
         int endReceiverRange = 0;
         //Launch execution of computation by batch
         List<Future<Boolean>> tasks = new ArrayList<>();
@@ -134,7 +136,7 @@ public class PathFinder {
             ThreadPathFinder batchThread = new ThreadPathFinder(endReceiverRange, newEndReceiver,
                     this, cellProgress, computeRaysOut.subProcess(cellProgress), data);
             if (threadCount != 1) {
-                tasks.add(threadManager.submitBlocking(batchThread));
+                tasks.add(threadManager.submit(batchThread));
             } else {
                 try {
                     batchThread.call();


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 style="margin-top: 0px; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The problem</h2><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PathFinder.run</code> divided the receivers of a cell into exactly one contiguous batch per thread. Receivers are ordered by primary key and so spatially grouped, and the computing time of a receiver varies a lot with its surroundings (number of sources in range, buildings), so the cell always waits for its slowest batch while the other threads stay idle at the end.</p><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The change (+4/−2 lines)</h2><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>The receivers are now divided into<span> </span><strong>16 batches per thread</strong>, so a thread that finishes a batch takes the next one from the queue. 16 is a compromise: enough batches to balance uneven areas, batches still large enough that the per-batch cost (one task and one visitor object) is negligible.</li><li>The batches are submitted with<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">submit</code><span> </span>instead of<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">submitBlocking</code>:<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">submitBlocking</code><span> </span>sleeps 100 ms as soon as more than<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">threadCount+1</code><span> </span>tasks are in flight, which starves the worker threads between small batches. Its protection against unbounded task queues is not needed here, since the number of batch objects is bounded by 16 × threadCount.</li></ul><h2 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Measurements (urban scene, 4 threads, identical output checksums)</h2>
  | Before | After
-- | -- | --
Sources concentrated in a corner (strong imbalance) | 4.6–4.8 s | 3.3 s (~30%)
Sources everywhere (balanced) | 2.05 s | 1.93 s

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The gain grows with how uneven the receiver workload is (city-edge cells, confined sources, mixed dense/sparse areas); balanced scenes still gain slightly and nothing regresses.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The pathfinder, propagation (CNOSSOS reference values) and jdbc attenuation test suites pass.</p><!--EndFragment-->
</body>
</html>