### PR TITLE
Precompute the frequency power terms of the ground effect

### DIFF
--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/AttenuationParameters.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/AttenuationParameters.java
@@ -52,6 +52,10 @@ public class AttenuationParameters {
      */
     public double pressure = Pref;
     public double[] alpha_atmo;
+    /** Frequency power terms of the ground effect equation (2.5.15), one value per frequency band */
+    public double[] groundFm25;
+    public double[] groundFm15;
+    public double[] groundFm075;
     public double defaultOccurrence = 0.5;
 
     public boolean gDisc = true;     // choose between accept G discontinuity or not
@@ -94,6 +98,9 @@ public class AttenuationParameters {
         this.humidity = other.humidity;
         this.pressure = other.pressure;
         this.alpha_atmo = other.alpha_atmo;
+        this.groundFm25 = other.groundFm25;
+        this.groundFm15 = other.groundFm15;
+        this.groundFm075 = other.groundFm075;
         this.defaultOccurrence = other.defaultOccurrence;
         this.gDisc = other.gDisc;
         this.prime2520 = other.prime2520;
@@ -114,6 +121,15 @@ public class AttenuationParameters {
     }
 
     protected void init() {
+        groundFm25 = new double[freq_lvl.size()];
+        groundFm15 = new double[freq_lvl.size()];
+        groundFm075 = new double[freq_lvl.size()];
+        for (int idFreq = 0; idFreq < freq_lvl.size(); idFreq++) {
+            int fm = freq_lvl.get(idFreq);
+            groundFm25[idFreq] = Math.pow(fm, 2.5);
+            groundFm15[idFreq] = Math.pow(fm, 1.5);
+            groundFm075[idFreq] = Math.pow(fm, 0.75);
+        }
         this.setTemperature(temperature);
     }
 

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/cnossos/AttenuationCnossos.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/cnossos/AttenuationCnossos.java
@@ -486,8 +486,9 @@ public class AttenuationCnossos {
         double dp = path.dp;
         double k = 2*PI*fm/c;
         double gw = forceGPath ? path.gPath : proPathParameters.isFavourable() ? path.gPath : path.gPathPrime;
-        double w = 0.0185 * pow(fm, 2.5) * pow(gw, 2.6) /
-                (pow(fm, 1.5) * pow(gw, 2.6) + 1.3e3 * pow(fm, 0.75) * pow(gw, 1.3) + 1.16e6);
+        double gw26 = pow(gw, 2.6);
+        double w = 0.0185 * data.groundFm25[idFreq] * gw26 /
+                (data.groundFm15[idFreq] * gw26 + 1.3e3 * data.groundFm075[idFreq] * pow(gw, 1.3) + 1.16e6);
         double cf = dp * (1 + 3 * w * dp * exp(-sqrt(w * dp))) / (1 + w * dp);
         return new double[]{cf, k, w};
     }


### PR DESCRIPTION
**The problem**
The w term of the ground effect (equation 2.5.15) computed three Math.pow of the band frequency on every call of computeCfKValues, plus pow(gw, 2.6) twice with the same arguments in the same expression. This method runs per frequency band, per segment, per path and per period, so these transcendental calls are among the most executed of the whole simulation.

**The change (+19/−2 lines)**
The three frequency terms (pow(fm, 2.5), pow(fm, 1.5), pow(fm, 0.75)) only depend on the frequency list, so they are now precomputed in AttenuationParameters when the frequencies are set (every constructor and setFrequencies go through init(); the copy constructor shares the arrays, like it already does for alpha_atmo).
pow(gw, 2.6) is computed once and reused inside the expression.
The formula keeps the same operations in the same order, so the results are exactly unchanged.

**Measurements**
Micro-benchmark of the attenuation step alone (paths built once, only computeCnossosAttenuation timed):

diffracted profile, 8 octave bands: 5.3 → 4.8 µs per path (−10%)
diffracted profile, 24 third-octave bands: 12.7 → 10.8 µs per path (−15%)
flat profile, 8 octave bands: 2.3 → 2.1 µs per path (−9%)
flat profile, 24 third-octave bands: 4.9 → 3.9 µs per path (−19%)
The gain grows with the number of bands. End to end, on a real city scene (41 receivers, ~58 000 road source points, 750 m propagation, 300 m order-2 reflections, diffractions, 24 threads), the run is 1 to 2% faster with identical result checksums — the attenuation step is a small share of such a run; the gain is larger for third-octave or many-period computations.

Results were checked to be bit-identical on the micro-benchmark checksums and on the city scene checksums, and the propagation reference tests and jdbc test suites pass.