### PR TITLE
Fix the comment of the source sort

### DIFF
--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
@@ -242,7 +242,7 @@ public class PathFinder {
                 }
             }
         }
-        // Sort sources by power contribution descending
+        // Sort sources by distance to the receiver, nearest first
         sourceList.sort(Comparator.comparingDouble(o -> receiverPointInfo.position.distance3D(o.position)));
 
         // Provides full sources points list to output data in order to do preprocessing step to evaluate


### PR DESCRIPTION
The comment said the sources are sorted by power contribution, but the sort key is the 3D distance to the receiver, nearest first. The pathfinder does not know the source emission, so it cannot sort by contribution; the distance order lets the maximum error early exit stop the loop as soon as possible. Only the comment changes.