### PR TITLE
Remove the unused wall spatial index of ProfileBuilder

### DIFF
--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/ProfileBuilder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/ProfileBuilder.java
@@ -73,8 +73,6 @@ public class ProfileBuilder {
     private List<Wall> walls = new ArrayList<>();
     /** Building RTree. */
     private final STRtree buildingTree;
-    /** Building RTree. */
-    private final STRtree wallTree = new STRtree(TREE_NODE_CAPACITY);
     /** RTree with Buildings's walls linestrings, walls linestring, GroundEffect linestrings
      * The object is an integer. It's an index of the array {@link #processedObstructions} */
     public STRtree rtree;
@@ -486,7 +484,6 @@ public class ProfileBuilder {
             );
         }
         walls.add(wall);
-        wallTree.insert(new Envelope(wall.line.p0, wall.line.p1), walls.size());
         return this;
     }
 


### PR DESCRIPTION
The wallTree index was filled with a segment envelope for every standalone wall in addWall, but nothing reads it: its last query was replaced by a query of the shared obstruction index in commit 7affb49b. The field is private and has no reader anywhere in the project (including the Groovy scripts). Removing it also skips one envelope and one index node per wall.