### PR TITLE
Prepare the ground effect footprints for the intersection tests

### DIFF
--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/GroundAbsorption.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/GroundAbsorption.java
@@ -10,11 +10,15 @@
 package org.noise_planet.noisemodelling.pathfinder.profilebuilder;
 
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 
 
 public class GroundAbsorption {
     /** Ground effect area footprint. */
     final Geometry geom;
+    /** Prepared version of the footprint, faster for the repeated intersection tests */
+    final PreparedGeometry preparedGeom;
     /** Ground effect coefficient. */
     final double coef;
 
@@ -26,6 +30,7 @@ public class GroundAbsorption {
     public GroundAbsorption(Geometry geom, double coef) {
         this.geom = geom;
         this.geom.normalize();
+        this.preparedGeom = PreparedGeometryFactory.prepare(this.geom);
         this.coef = coef;
     }
 

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/ProfileBuilder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/profilebuilder/ProfileBuilder.java
@@ -1028,7 +1028,7 @@ public class ProfileBuilder {
             for (Object groundEffectAreaIndex : res) {
                 if(groundEffectAreaIndex instanceof Integer) {
                     GroundAbsorption groundAbsorption = groundAbsorptions.get((Integer) groundEffectAreaIndex);
-                    if(groundAbsorption.geom.intersects(query)) {
+                    if(groundAbsorption.preparedGeom.intersects(query)) {
                         return (Integer) groundEffectAreaIndex;
                     }
                 }
@@ -1109,7 +1109,7 @@ public class ProfileBuilder {
         Vector2D directionAfter = Vector2D.create(fullLine.p0, fullLine.p1).normalize().multiply(MILLIMETER);
         Point afterIntersectionPoint = FACTORY.createPoint(Vector2D.create(intersection).add(directionAfter).toCoordinate());
         GroundAbsorption groundAbsorption = groundAbsorptions.get(facetLine.getOriginId());
-        if (groundAbsorption.geom.intersects(afterIntersectionPoint)) {
+        if (groundAbsorption.preparedGeom.intersects(afterIntersectionPoint)) {
             // we enter a new ground effect
             newCutPoints.add(new CutPointGroundEffect(processedWallIndex, intersection, groundAbsorption.getCoefficient()));
         } else {


### PR DESCRIPTION
**The problem**
The ground absorption surfaces are stored as plain geometries, so every point test of the cut profile construction — the classification of the source position, then one to three tests per crossed ground border — runs a full relate operation on non-rectangular footprints. These tests run for every cut profile, and real landcover polygons are often large multi-part geometries where each relate builds an expensive geometry graph.

**The change (+7/−2 lines)**
GroundAbsorption also stores a PreparedGeometry of its footprint, created when the surface is added, and the two intersection test call sites use it. A prepared intersection returns the same values, it is only faster on repeated calls against the same polygon. Its lazy internal index is safe to share between the computation threads (the accessors are synchronized in JTS since 1.16). The touches() test between two surfaces is not changed.

**Measurements**
Real city scene (41 receivers, ~58 000 road source points, real landcover polygons, 750 m propagation, order-2 reflections, 24 threads): 2 to 3% faster, consistent over 4 interleaved before/after pairs, including pairs run in reversed order to rule out a measurement bias. All result checksums are identical, and the pathfinder and jdbc test suites pass.

The gain depends on the complexity of the landcover polygons: a synthetic scene with small simple polygons shows no measurable difference, real landcover does.