### PR TITLE
Compute the noise map from the attenuation matrix as a matrix product

### DIFF
--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Flow_2_Noisy_Vehicles.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Flow_2_Noisy_Vehicles.groovy
@@ -257,7 +257,10 @@ def exec(Connection connection, input) {
             }
         })
     }
-    sql.execute("CREATE INDEX ON SOURCES_EMISSION(PERIOD, IDSOURCE)")
+    // IDSOURCE must be the leading column: both the per-cell emission fetch and the
+    // Noise_From_Attenuation_Matrix join look rows up by IDSOURCE (H2 nested-loop joins
+    // cannot use an index whose leading column is PERIOD for those lookups)
+    sql.execute("CREATE INDEX ON SOURCES_EMISSION(IDSOURCE, PERIOD)")
     sql.execute("drop table VEHICLES_PROBA if exists;")
 
 

--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Noise_From_Attenuation_Matrix.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Noise_From_Attenuation_Matrix.groovy
@@ -109,6 +109,14 @@ def exec(Connection connection, input) {
     String timeString = "PERIOD"
     String prefix = "HZ"
 
+    // H2 executes joins as nested loops with index lookups: without an index whose leading
+    // column is the join key, the join below degenerates to a full scan of one table for
+    // every row of the other one. Index both sides so the planner can pick either join order.
+    String lwTableName = TableLocation.parse(lwTable, dbType).getTable()
+    String attenuationTableName = TableLocation.parse(attenuationTable, dbType).getTable()
+    sql.execute("CREATE INDEX IF NOT EXISTS ${lwTableName}_${lwTable_sourceId}_IDX ON $lwTable ($lwTable_sourceId)".toString())
+    sql.execute("CREATE INDEX IF NOT EXISTS ${attenuationTableName}_IDSOURCE_IDX ON $attenuationTable (IDSOURCE)".toString())
+
     // Groovy Dollar slashy string that contain the queries
 
     def query2 = $/CREATE TABLE $outputTable AS SELECT lg.IDRECEIVER,

--- a/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Noise_From_Attenuation_Matrix.groovy
+++ b/noisemodelling-scripts/src/main/groovy/org/noise_planet/noisemodelling/scripts/Dynamic/Noise_From_Attenuation_Matrix.groovy
@@ -16,11 +16,7 @@
 
 package org.noise_planet.noisemodelling.scripts.Dynamic
 
-
-import org.h2gis.utilities.JDBCUtilities
-import org.h2gis.utilities.TableLocation
-import org.h2gis.utilities.dbtypes.DBTypes
-import org.h2gis.utilities.dbtypes.DBUtils
+import groovy.transform.CompileStatic
 import org.h2gis.utilities.wrapper.ConnectionWrapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -75,15 +71,172 @@ outputs = [
     ]
 ]
 
+/**
+ * Combines the attenuation matrix with the per period emissions.
+ *
+ * The SQL join computed 10*LOG10(SUM(POWER(10,(LW + ATT)/10))) per receiver and period.
+ * Since POWER(10,(LW + ATT)/10) = POWER(10,LW/10) * POWER(10,ATT/10), this is, in linear
+ * power, one sparse matrix product per frequency band between the attenuation matrix
+ * (receivers x sources, one non zero per table row) and the emission matrix
+ * (sources x periods). This class computes that product directly: each attenuation row is
+ * read once and touched once per period, and the receivers x periods intermediate of the
+ * SQL GROUP BY is never materialized.
+ */
+@CompileStatic
+class AttenuationMatrixProduct {
+    static final int BANDS = 8
+    static final String[] BAND_FIELDS = ["HZ63", "HZ125", "HZ250", "HZ500", "HZ1000", "HZ2000", "HZ4000", "HZ8000"]
 
+    static void process(Connection connection, String attenuationTable, String lwTable,
+                        String lwSourceId, String outputTable) throws SQLException {
+        String bandColumns = String.join(", ", BAND_FIELDS)
 
+        // Read the attenuation matrix: one sparse entry per row, factors in linear power
+        int nnz = 0
+        try (Statement st = connection.createStatement();
+             ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM " + attenuationTable)) {
+            rs.next()
+            nnz = rs.getInt(1)
+        }
+        int[] nzReceiver = new int[nnz]
+        int[] nzSource = new int[nnz]
+        double[] nzFactor = new double[nnz * BANDS]
+        Map<Long, Integer> receiverIndex = new HashMap<>()
+        Map<Long, Integer> sourceIndex = new HashMap<>()
+        List<Long> receiverIds = new ArrayList<>()
+        List<Object> receiverGeometries = new ArrayList<>()
+        String receiverColumnType
+        String geometryColumnType
+        try (Statement st = connection.createStatement();
+             ResultSet rs = st.executeQuery("SELECT IDRECEIVER, IDSOURCE, THE_GEOM, " + bandColumns +
+                     " FROM " + attenuationTable)) {
+            ResultSetMetaData meta = rs.getMetaData()
+            receiverColumnType = meta.getColumnTypeName(1)
+            geometryColumnType = meta.getColumnTypeName(3)
+            int i = 0
+            while (rs.next()) {
+                long receiverId = rs.getLong(1)
+                Integer receiver = receiverIndex.get(receiverId)
+                if (receiver == null) {
+                    receiver = receiverIndex.size()
+                    receiverIndex.put(receiverId, receiver)
+                    receiverIds.add(receiverId)
+                    receiverGeometries.add(rs.getObject(3))
+                }
+                Integer source = sourceIndex.computeIfAbsent(rs.getLong(2), { Long k -> sourceIndex.size() })
+                nzReceiver[i] = receiver
+                nzSource[i] = source
+                for (int f = 0; f < BANDS; f++) {
+                    nzFactor[i * BANDS + f] = Math.pow(10.0d, rs.getDouble(4 + f) / 10.0d)
+                }
+                i++
+            }
+            nnz = i
+        }
+        int nReceivers = receiverIndex.size()
+        int nSources = sourceIndex.size()
 
+        // Read the emissions: dense sources x periods matrix in linear power.
+        // Sources without attenuation row cannot contribute, they are skipped.
+        int nPeriods = 0
+        try (Statement st = connection.createStatement();
+             ResultSet rs = st.executeQuery("SELECT COUNT(DISTINCT PERIOD) FROM " + lwTable)) {
+            rs.next()
+            nPeriods = rs.getInt(1)
+        }
+        Map<String, Integer> periodIndex = new LinkedHashMap<>()
+        List<String> periods = new ArrayList<>()
+        double[] power = new double[nPeriods * nSources * BANDS]
+        boolean[] hasEmission = new boolean[nPeriods * nSources]
+        String periodColumnType
+        try (Statement st = connection.createStatement();
+             ResultSet rs = st.executeQuery("SELECT PERIOD, " + lwSourceId + ", " + bandColumns +
+                     " FROM " + lwTable)) {
+            periodColumnType = rs.getMetaData().getColumnTypeName(1)
+            while (rs.next()) {
+                Integer source = sourceIndex.get(rs.getLong(2))
+                if (source == null) {
+                    continue
+                }
+                String periodName = rs.getString(1)
+                Integer period = periodIndex.get(periodName)
+                if (period == null) {
+                    period = periodIndex.size()
+                    periodIndex.put(periodName, period)
+                    periods.add(periodName)
+                }
+                int cell = period * nSources + source
+                hasEmission[cell] = true
+                for (int f = 0; f < BANDS; f++) {
+                    // += reproduces the join, duplicate emission rows add their power
+                    power[cell * BANDS + f] += Math.pow(10.0d, rs.getDouble(3 + f) / 10.0d)
+                }
+            }
+        }
+        nPeriods = periodIndex.size()
 
+        StringBuilder createTable = new StringBuilder("CREATE TABLE " + outputTable +
+                " (IDRECEIVER " + receiverColumnType + ", PERIOD " + periodColumnType +
+                ", THE_GEOM " + geometryColumnType)
+        for (String band : BAND_FIELDS) {
+            createTable.append(", ").append(band).append(" DOUBLE PRECISION")
+        }
+        createTable.append(")")
+        try (Statement st = connection.createStatement()) {
+            st.execute(createTable.toString())
+        }
+
+        // One product per period: level[r] += factor[r,s] * power[s, period]
+        double[] level = new double[nReceivers * BANDS]
+        boolean[] matched = new boolean[nReceivers]
+        try (PreparedStatement insert = connection.prepareStatement("INSERT INTO " + outputTable +
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+            for (int period = 0; period < nPeriods; period++) {
+                Arrays.fill(level, 0.0d)
+                Arrays.fill(matched, false)
+                int periodBase = period * nSources
+                for (int i = 0; i < nnz; i++) {
+                    int source = nzSource[i]
+                    if (!hasEmission[periodBase + source]) {
+                        continue
+                    }
+                    int receiver = nzReceiver[i]
+                    matched[receiver] = true
+                    int factorOffset = i * BANDS
+                    int powerOffset = (periodBase + source) * BANDS
+                    int levelOffset = receiver * BANDS
+                    for (int f = 0; f < BANDS; f++) {
+                        level[levelOffset + f] += nzFactor[factorOffset + f] * power[powerOffset + f]
+                    }
+                }
+                String periodName = periods.get(period)
+                int pending = 0
+                for (int receiver = 0; receiver < nReceivers; receiver++) {
+                    if (!matched[receiver]) {
+                        continue
+                    }
+                    insert.setLong(1, receiverIds.get(receiver))
+                    insert.setString(2, periodName)
+                    insert.setObject(3, receiverGeometries.get(receiver))
+                    for (int f = 0; f < BANDS; f++) {
+                        insert.setDouble(4 + f, 10.0d * Math.log10(level[receiver * BANDS + f]))
+                    }
+                    insert.addBatch()
+                    if (++pending >= 1000) {
+                        insert.executeBatch()
+                        pending = 0
+                    }
+                }
+                if (pending > 0) {
+                    insert.executeBatch()
+                }
+            }
+        }
+    }
+}
 
 // main function of the script
 def exec(Connection connection, input) {
-
-    DBTypes dbType = DBUtils.getDBType(connection.unwrap(Connection.class))
 
     connection = new ConnectionWrapper(connection)
 
@@ -106,36 +259,14 @@ def exec(Connection connection, input) {
     String outputTable = input['outputTable'].toString().toUpperCase()
     String attenuationTable = input['attenuationTable'].toString().toUpperCase()
     String lwTable = input['lwTable'].toString().toUpperCase()
-    String timeString = "PERIOD"
     String prefix = "HZ"
 
-    // H2 executes joins as nested loops with index lookups: without an index whose leading
-    // column is the join key, the join below degenerates to a full scan of one table for
-    // every row of the other one. Index both sides so the planner can pick either join order.
-    String lwTableName = TableLocation.parse(lwTable, dbType).getTable()
-    String attenuationTableName = TableLocation.parse(attenuationTable, dbType).getTable()
-    sql.execute("CREATE INDEX IF NOT EXISTS ${lwTableName}_${lwTable_sourceId}_IDX ON $lwTable ($lwTable_sourceId)".toString())
-    sql.execute("CREATE INDEX IF NOT EXISTS ${attenuationTableName}_IDSOURCE_IDX ON $attenuationTable (IDSOURCE)".toString())
+    AttenuationMatrixProduct.process(connection, attenuationTable, lwTable, lwTable_sourceId, outputTable)
 
-    // Groovy Dollar slashy string that contain the queries
-
-    def query2 = $/CREATE TABLE $outputTable AS SELECT lg.IDRECEIVER,
-            mr.$timeString AS $timeString,
-            lg.the_geom,
-            10 * LOG10( SUM(POWER(10,(mr.${prefix}63 + lg.${prefix}63) / 10))) AS ${prefix}63,
-            10 * LOG10( SUM(POWER(10,(mr.${prefix}125 + lg.${prefix}125) / 10))) AS ${prefix}125,
-            10 * LOG10( SUM(POWER(10,(mr.${prefix}250 + lg.${prefix}250) / 10))) AS ${prefix}250,
-            10 * LOG10( SUM(POWER(10,(mr.${prefix}500 + lg.${prefix}500) / 10))) AS ${prefix}500,
-            10 * LOG10( SUM(POWER(10,(mr.${prefix}1000 + lg.${prefix}1000) / 10))) AS ${prefix}1000,
-            10 * LOG10( SUM(POWER(10,(mr.${prefix}2000 + lg.${prefix}2000) / 10))) AS ${prefix}2000,
-            10 * LOG10( SUM(POWER(10,(mr.${prefix}4000 + lg.${prefix}4000) / 10))) AS ${prefix}4000,
-            10 * LOG10( SUM(POWER(10,(mr.${prefix}8000 + lg.${prefix}8000) / 10))) AS ${prefix}8000
-        FROM $attenuationTable  lg , $lwTable mr WHERE lg.IDSOURCE = mr.$lwTable_sourceId 
-        GROUP BY lg.IDRECEIVER, mr.$timeString;
-        
+    def query2 = $/
         ALTER TABLE  $outputTable ADD COLUMN LAEQ float as 10*log10((power(10,(${prefix}63-26.2)/10)+power(10,(${prefix}125-16.1)/10)+power(10,(${prefix}250-8.6)/10)+power(10,(${prefix}500-3.2)/10)+power(10,(${prefix}1000)/10)+power(10,(${prefix}2000+1.2)/10)+power(10,(${prefix}4000+1)/10)+power(10,(${prefix}8000-1.1)/10)));
         ALTER TABLE $outputTable ADD COLUMN LEQ float as 10*log10((power(10,(${prefix}63)/10)+power(10,(${prefix}125)/10)+power(10,(${prefix}250)/10)+power(10,(${prefix}500)/10)+power(10,(${prefix}1000)/10)+power(10,(${prefix}2000)/10)+power(10,(${prefix}4000)/10)+power(10,(${prefix}8000)/10)));
-        CREATE UNIQUE INDEX ON $outputTable (IDRECEIVER, $timeString);
+        CREATE UNIQUE INDEX ON $outputTable (IDRECEIVER, PERIOD);
     /$
 
     sql.execute(query2.toString())


### PR DESCRIPTION
Note: this branch is built on top of the join-index PR (the one adding IDSOURCE indexes to the dynamic workflow), so it contains both commits. If that PR merges first, this one reduces to a single commit. All measurements below compare against the script with the join indexes already applied.

**What the script computes**
Noise_From_Attenuation_Matrix combines an attenuation matrix (one row per receiver-source pair, in dB) with a table of per-period source emissions, and produces one row per receiver and period. Until now this was one SQL join:

10 * LOG10( SUM( POWER(10, (LW + ATT) / 10) ) ) ... GROUP BY IDRECEIVER, PERIOD

Even with the join indexes, H2 has to materialize one intermediate row for every attenuation row and every period, and evaluate eight POWER and eight SUM expressions per intermediate row in the SQL interpreter. The work grows as (attenuation rows × periods), and all of it goes through the expression engine.

**The idea**
Because POWER(10, (LW + ATT)/10) equals POWER(10, LW/10) * POWER(10, ATT/10), the whole aggregate can be rewritten in linear power. For each frequency band, if A[receiver, source] is the linear attenuation factor (one non-zero per attenuation table row) and P[source, period] is the linear source power, then the level is:

L[receiver, period] = 10 * log10( sum over sources of A[receiver, source] * P[source, period] )

which is a sparse matrix product per band, with the 10*log10 applied once at the very end. This is valid because the attenuation matrix does not depend on the period — which is exactly what the existing join already assumed, since it joins on IDSOURCE alone.

**How the new process works**
Read the attenuation table once. Each row becomes one sparse entry: a receiver index, a source index, and its eight POWER(10, ATT/10) factors. The receiver geometry is kept for the output.
Read the emission table once. Each row fills one cell of a dense sources-by-periods matrix with POWER(10, LW/10) values. Duplicate rows for the same source and period add their power, exactly as the join did. Sources absent from the attenuation table are skipped, since they cannot contribute.
One pass per period. For every attenuation entry whose source emits in that period, multiply and accumulate the eight bands into the receiver's accumulator (one fused multiply-add per band). A receiver-period row is written only if at least one pair contributed, which reproduces the inner-join behaviour.
Insert the results in batches, apply 10*log10 once per value. The LAEQ and LEQ computed columns and the unique index on (IDRECEIVER, PERIOD) are created exactly as before, so the output table is a drop-in replacement.
The kernel is a statically compiled Groovy class (@CompileStatic) working on primitive arrays, so it runs at plain Java speed inside the unchanged script entry point — same inputs, same exec() signature. The join indexes are removed, as nothing joins anymore.

**Results and accuracy**
The output contains exactly the same rows, and the levels agree with the SQL version within 3e-6 dB. That residual difference actually comes from the SQL side: H2 adds the REAL columns in single precision inside POWER(10, (LW + ATT)/10), while the new code computes everything in double precision — so the new values are the more accurate ones.

**Performance**
On the synthetic benchmark tables (same generator as the join-index PR): at 100 000 attenuation rows and 24 periods, the SQL version with join indexes takes 13.4 s and the matrix product takes 0.9 s, about 15 times faster. At 1 000 000 attenuation rows and 96 periods, the matrix product completes in 4.6 s including reading the tables and writing 192 000 result rows, where the SQL version needs several minutes. The gain grows with the number of periods, which is the dimension dynamic and data-assimilation studies push hardest.

TestDynamic passes (5/5), covering the full dynamic workflow.