### PR TITLE
Fix calculation of convex hull length for lateral diffraction

### DIFF
--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
@@ -489,13 +489,12 @@ public class PathFinder {
         }
 
         // Intersection test cache
-        Set<LineSegment> freeFieldSegments = new HashSet<>();
 
         List<Coordinate> input = new ArrayList<>();
 
-        Coordinate[] coordinates = new Coordinate[0];
-        int indexp1 = 0;
-        int indexp2 = 0;
+        Coordinate[] coordinates;
+        int indexp1;
+        int indexp2;
 
         input.add(p1);
         input.add(p2);
@@ -511,20 +510,11 @@ public class PathFinder {
 
         data.profileBuilder.getWallsOnPath(p1, p2, buildingIntersectionPathVisitor);
 
-        int k;
-
         ConvexHull convexHull = new ConvexHull(input.toArray(new Coordinate[0]), GEOMETRY_FACTORY);
         Geometry convexhull = convexHull.getConvexHull();
 
         coordinates = convexhull.getCoordinates();
         // for the length we do not count the return ray from receiver to source (closed polygon here)
-        double convexHullLength = Length.ofLine(
-                CoordinateArraySequenceFactory.instance()
-                        .create(Arrays.copyOfRange(coordinates, left ? 1 : 0, coordinates.length - (left ? 0 : 1))));
-        if (convexHullLength / p1.distance(p2) > MAX_RATIO_HULL_DIRECT_PATH ||
-                convexHullLength >= data.maxSrcDist) {
-            return new ArrayList<>();
-        }
 
         input.clear();
         input.addAll(Arrays.asList(coordinates));
@@ -565,12 +555,21 @@ public class PathFinder {
         }
 
         // restore coordinates order from source to receiver
+        Coordinate[] output;
         if (left) {
-            return Arrays.asList(Arrays.copyOfRange(coordinates, indexp1, indexp2 + 1));
+            output = Arrays.copyOfRange(coordinates, indexp1, indexp2 + 1);
         } else {
-            List<Coordinate> inversePath = Arrays.asList(Arrays.copyOfRange(coordinates, indexp2, coordinates.length));
-            Collections.reverse(inversePath);
-            return inversePath;
+            output = Arrays.copyOfRange(coordinates, indexp2, coordinates.length);
+            // reverse output
+            CoordinateArrays.reverse(output);
+        }
+
+        double convexHullLength = Length.ofLine(CoordinateArraySequenceFactory.instance().create( output ) );
+        if (convexHullLength / p1.distance(p2) > MAX_RATIO_HULL_DIRECT_PATH ||
+                convexHullLength >= data.maxSrcDist) {
+            return new ArrayList<>();
+        } else {
+            return Arrays.asList(output);
         }
     }
 

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PathFinder.java
@@ -520,7 +520,7 @@ public class PathFinder {
         // for the length we do not count the return ray from receiver to source (closed polygon here)
         double convexHullLength = Length.ofLine(
                 CoordinateArraySequenceFactory.instance()
-                        .create(Arrays.copyOfRange(coordinates, 0, coordinates.length - 1)));
+                        .create(Arrays.copyOfRange(coordinates, left ? 1 : 0, coordinates.length - (left ? 0 : 1))));
         if (convexHullLength / p1.distance(p2) > MAX_RATIO_HULL_DIRECT_PATH ||
                 convexHullLength >= data.maxSrcDist) {
             return new ArrayList<>();

--- a/noisemodelling-pathfinder/src/test/java/org/noise_planet/noisemodelling/pathfinder/TestPathFinder.java
+++ b/noisemodelling-pathfinder/src/test/java/org/noise_planet/noisemodelling/pathfinder/TestPathFinder.java
@@ -281,4 +281,51 @@ public class TestPathFinder {
             assertFalse(Double.isNaN(pt.y));
         }
     }
+
+
+    /**
+     * Test regression on https://github.com/Universite-Gustave-Eiffel/NoiseModelling/issues/1031
+     *
+     * @throws ParseException
+     */
+    @Test
+    public void TestHullRegression() throws ParseException {
+        GeometryFactory factory = new GeometryFactory();
+        WKTReader wktReader = new WKTReader(factory);
+        //Scene dimension
+        //Envelope cellEnvelope = new Envelope(new Coordinate(0, 0, 0.), new Coordinate(20, 15, 0.));
+        //Create obstruction test object
+        ProfileBuilder profileBuilder = new ProfileBuilder();
+        profileBuilder.addBuilding(wktReader.read("POLYGON((5 6 4, 4 5 4, 7 5 4, 7 8 4, 4 8 4, 5 7 4, 5 6 4))"), -1);
+        profileBuilder.finishFeeding();
+
+        Scene processData = new Scene(profileBuilder);
+        PathFinder computeRays = new PathFinder(processData);
+
+        // Right hull length is 6.68m
+        // Left hull length is 7.08m
+        // We reject left hull with max src dist
+        computeRays.getData().maxSrcDist = 6.8;
+
+        Coordinate p1 = new Coordinate(5.643, 8.912, 1.6);
+        Coordinate p2 = new Coordinate(5.610, 3.531, 1.6);
+        // Top down
+        List<Coordinate> ray = computeRays.computeSideHull(true, p1, p2);
+        assertEquals(4, ray.size());
+        assertEquals(p1, ray.getFirst());
+        assertEquals(p2, ray.getLast());
+
+        ray = computeRays.computeSideHull(false, p1, p2);
+        assertTrue(ray.isEmpty());
+
+        // Down top
+        ray = computeRays.computeSideHull(true, p2, p1);
+        assertTrue(ray.isEmpty());
+
+        ray = computeRays.computeSideHull(false, p2, p1);
+        assertEquals(4, ray.size());
+        assertEquals(p2, ray.getFirst());
+        assertEquals(p1, ray.getLast());
+
+    }
 }


### PR DESCRIPTION
This is the fix for issue report #1031 "Pathfinder: different numbers of left and right diffraction paths found for a symmetrical  setup."

A part of the code that calculates the convex hull length
`.create(Arrays.copyOfRange(coordinates, 0, coordinates.length - 1)));`
in PathFinder.java should be
`.create(Arrays.copyOfRange(coordinates, left ? 1 : 0, coordinates.length - (left ? 0 : 1))));`
because we need to consider the orientation of the convex hull.