### PR TITLE
Keep a running sum of the maxError remaining power budget

### DIFF
--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/output/AttenuationOutputSingleThread.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/output/AttenuationOutputSingleThread.java
@@ -61,6 +61,14 @@ public class AttenuationOutputSingleThread implements CutPlaneVisitor {
      */
     Map<String, HashMap<SourcePointKey, Double>> maximumWjExpectedSplAtReceiver = new HashMap<>();
 
+    /**
+     * MaxError DB Processing variable
+     * Sum of the maximumWjExpectedSplAtReceiver values for each period.
+     * Updated when a value is added or removed, so the pruning check does not have
+     * to sum the values of all the remaining sources for every propagation path.
+     */
+    Map<String, Double> maximumWjExpectedSplAtReceiverTotal = new HashMap<>();
+
     public AtomicInteger cutProfileCount = new AtomicInteger(0);
 
     ProgressVisitor progressVisitor;
@@ -178,9 +186,13 @@ public class AttenuationOutputSingleThread implements CutPlaneVisitor {
                 for (SceneWithEmission.PeriodEmission periodEmission : emissions) {
                     final String periodLabel = periodEmission.period;
                     if (maximumWjExpectedSplAtReceiver.containsKey(periodLabel)) {
-                        maximumWjExpectedSplAtReceiver.get(periodLabel).remove(sourcePointKey);
+                        Double removedPower = maximumWjExpectedSplAtReceiver.get(periodLabel).remove(sourcePointKey);
+                        if (removedPower != null) {
+                            maximumWjExpectedSplAtReceiverTotal.merge(periodLabel, -removedPower, Double::sum);
+                        }
                         if (maximumWjExpectedSplAtReceiver.get(periodLabel).isEmpty()) {
                             maximumWjExpectedSplAtReceiver.remove(periodLabel);
+                            maximumWjExpectedSplAtReceiverTotal.remove(periodLabel);
                         }
                     }
                 }
@@ -195,8 +207,9 @@ public class AttenuationOutputSingleThread implements CutPlaneVisitor {
 
                     // Evaluate the current noise level at receiver compared to the final
                     // expected noise level at the receiver.
-                    double nonProcessedPower = maximumWjExpectedSplAtReceiver.get(entryPeriod).values().stream()
-                            .reduce(Double::sum).orElse(0.0);
+                    // The sum can be slightly negative because of rounding, clamp it to zero.
+                    double nonProcessedPower = Math.max(0.0,
+                            maximumWjExpectedSplAtReceiverTotal.getOrDefault(entryPeriod, 0.0));
                     double maximumExpectedLevelInDb = AcousticIndicatorsFunctions.wToDb(levelAtReceiver + nonProcessedPower);
                     double dBDiff = maximumExpectedLevelInDb - wToDb(levelAtReceiver);
                     if (dBDiff > dbSettings.maximumError) {
@@ -299,6 +312,7 @@ public class AttenuationOutputSingleThread implements CutPlaneVisitor {
                 wjAtReceiver.put(period, 0.0);
             }
             maximumWjExpectedSplAtReceiver.clear();
+            maximumWjExpectedSplAtReceiverTotal.clear();
 
             final SceneWithEmission scene = multiThread.sceneWithEmission;
             for (PathFinder.SourcePointInfo sourcePointInfo : sourceList) {
@@ -334,6 +348,7 @@ public class AttenuationOutputSingleThread implements CutPlaneVisitor {
                             sourceLevel = maximumWjExpectedSplAtReceiver.get(periodEmission.period);
                         }
                         sourceLevel.merge(new SourcePointKey(sourcePointInfo), sumPower, Double::sum);
+                        maximumWjExpectedSplAtReceiverTotal.merge(periodEmission.period, sumPower, Double::sum);
                     }
                 }
             }
@@ -465,6 +480,7 @@ public class AttenuationOutputSingleThread implements CutPlaneVisitor {
         }
         receiverAttenuationList.clear();
         maximumWjExpectedSplAtReceiver.clear();
+        maximumWjExpectedSplAtReceiverTotal.clear();
         wjAtReceiver.clear();
         this.attenuationOutputs.clear();
     }


### PR DESCRIPTION
## The problem

The maximum error shortcut keeps, per period, the expected remaining power of every source not yet processed. For **every** propagation path produced — direct, each lateral diffraction, each reflection — and for every period, the check re-summed that whole map with `values().stream().reduce(Double::sum)`, boxing one `Double` per remaining source.

The cost is quadratic in the number of sources in range of a receiver, and it is worst exactly where the pruning fails to trigger early, which is the dense-source case the shortcut is meant to help. The shortcut is enabled by default (`maximumError = 0.1` dB).

## The change

A running total per period is kept alongside the map: it is increased when a source budget is added in the receiver pre-pass, decreased when a source is removed after being processed, and the check reads it instead of re-summing. The total is clamped to zero on read, since repeated additions and subtractions of doubles can leave a very small negative residue.

The pruning decisions and the results are unchanged.

## Measurements

Pruning-stress scene (4 000 sources on a ring, 3 periods, 100 receivers, single thread, maxError 0.1 dB — sources at equal distance and equal power, so the shortcut only fires late):

- before: 33.1 s and 34.3 s
- after: 5.0 s and 5.1 s

That is 6.7 times faster on this scene, with identical result checksums (count, per-band sums, LAEQ, LEQ). Two interleaved before/after pairs. The gain grows with the number of sources per receiver; a smaller 1 500-source scene measured 2.2 s to 0.8 s.

The pathfinder (93 tests), propagation (53) and jdbc (58) test suites all pass.

## Note for the reviewer

This branch was rebased onto current main after PR #999 (the maxError period mix-up fix) was merged; the two touch the same line, and this version reads the running total with the `entryPeriod` key introduced by that fix, so the period behaviour it corrected is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
