### PR TITLE
Fix broken H2GIS links in the documentation

### DIFF
--- a/Docs/Architecture.rst
+++ b/Docs/Architecture.rst
@@ -45,7 +45,7 @@ In both cases, database can be local or remote.
 
 
 .. _H2 : https://www.h2database.com
-.. _H2GIS: https://www.h2gis.org/
+.. _H2GIS: https://h2gis.org/
 .. _PostgreSQL: https://www.postgresql.org/
 .. _PostGIS: https://postgis.net/
 

--- a/Docs/Installation_guide.rst
+++ b/Docs/Installation_guide.rst
@@ -114,8 +114,6 @@ Please execute:
 .. tip::
     NoiseModelling will stay open as long as the command window is open. If you close it, NoiseModelling will automatically stop and the GUI will no longer be available.
 
-.. _H2GIS : http://www.h2gis.org/Load input files
-
 Step 4: Open NoiseModelling GUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Docs/NoiseModelling_db.rst
+++ b/Docs/NoiseModelling_db.rst
@@ -11,7 +11,7 @@ This database does not need to be configured or installed on the system. It's tr
 .. tip ::
     Many spatial processing are possible with H2GIS. Please have a look to the numerous functions on the `H2GIS website`_.
 
-.. _H2GIS website: http://www.h2gis.org/docs/dev/functions/
+.. _H2GIS website: https://h2gis.readthedocs.io/en/latest/
 
 To visualize and manage NoiseModelling data (*e.g* roads, buildings or landcover layers) you have the choice between the three following approaches *(listed from simple to advanced)*:
 


### PR DESCRIPTION
Three H2GIS links in `Docs/` no longer work.

`Architecture.rst` points `H2GIS`_ at `https://www.h2gis.org/`. The `www` subdomain has no working HTTPS, so that URL fails to connect. Changed to `https://h2gis.org/`.

`NoiseModelling_db.rst` points the "numerous functions" tip at `http://www.h2gis.org/docs/dev/functions/`, which 404s. The H2GIS function reference moved to ReadTheDocs, which is where h2gis.org itself now links. Changed to `https://h2gis.readthedocs.io/en/latest/`.

`Installation_guide.rst` had `.. _H2GIS : http://www.h2gis.org/Load input files`. The URL contains spaces, and no `H2GIS`_ reference exists anywhere in that file, so it is an unreferenced target that Sphinx warns about. Removed it. Say the word if you would rather it were repaired and referenced instead, and I will do that.

Verified with curl: `https://www.h2gis.org/` fails to connect while `https://h2gis.org/` and `https://h2gis.readthedocs.io/en/latest/` both return 200, and `http://www.h2gis.org/docs/dev/functions/` returns 404.

I left the 404s under `noisemodelling-scripts/.../vendor/highlight/` alone since that is vendored third-party code.